### PR TITLE
fix license verifier for trial licenses

### DIFF
--- a/licverifier/verifier.go
+++ b/licverifier/verifier.go
@@ -111,7 +111,7 @@ func toLicenseInfo(token jwt.Token) (LicenseInfo, error) {
 		return LicenseInfo{}, err
 	}
 	accID, ok := claims[accountID].(float64)
-	if !ok || ok && accID <= 0 {
+	if !ok || ok && accID < 0 {
 		return LicenseInfo{}, errors.New("Invalid accountId in claims")
 	}
 	orgName, ok := claims[organization].(string)

--- a/licverifier/verifier_test.go
+++ b/licverifier/verifier_test.go
@@ -48,7 +48,8 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 		lic             string
 		expectedLicInfo LicenseInfo
 		shouldPass      bool
-	}{{"", LicenseInfo{}, false},
+		iat             time.Time
+	}{{"", LicenseInfo{}, false, time.Now()},
 		{"eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJrYW5hZ2FyYWorYzFAbWluaW8uaW8iLCJjYXAiOjUwLCJvcmciOiJHcmluZ290dHMgSW5jLiIsImV4cCI6MS42NDE0NDYxNjkwMDExOTg4OTRlOSwicGxhbiI6IlNUQU5EQVJEIiwiaXNzIjoic3VibmV0QG1pbi5pbyIsImFpZCI6MSwiaWF0IjoxLjYwOTkxMDE2OTAwMTE5ODg5NGU5fQ.EhTL2xwMHnUoLQF4UR-5bjUCja3whseLU5mb9XEj7PvAae6HEIDCOMEF8Hhh20DN_v_LRE283j2ZlA5zulcXSZXS0CLcrKqbVy6QLvZfvvLuerOjJI-NBa9dSJWJ0WoN", LicenseInfo{
 			Email:           "kanagaraj+c1@minio.io",
 			Organization:    "Gringotts Inc.",
@@ -56,14 +57,22 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 			StorageCapacity: 50,
 			Plan:            "STANDARD",
 			ExpiresAt:       time.Date(2022, time.January, 6, 5, 16, 9, 0, time.UTC),
-		}, true},
+		}, true, time.Unix(int64(1609910169), 0)},
+		{"eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbkBzdG9yYWdlLWl0LmNvbSIsImNhcCI6MTAsIm9yZyI6IlN0b3JhZ2VJVCIsImV4cCI6MS42MjU4NTY5NjMxOTQ3NzYzMWU5LCJwbGFuIjoiVFJJQUwiLCJpc3MiOiJrYW5hZ2FyYWpAbWluaW8uaW8iLCJhaWQiOjAsImlhdCI6MS42MjM0Mzc3NjMxOTQ3NzYzMWU5LCJsaWQiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAifQ.2vBsvURSIrRqrBwpN1dXUcuVxaHIsT3yvAU7SRgUZ5XWHVGF66LR-KlxTWEdU_vThIzvr7vPe-W-quciNxvFaEEmmKDpMfk16jq1wHPcK0gLU5cey6-w4CaEUTxqfiz_", LicenseInfo{
+			Email:           "admin@storage-it.com",
+			Organization:    "StorageIT",
+			AccountID:       0,
+			StorageCapacity: 10,
+			Plan:            "TRIAL",
+			ExpiresAt:       time.Date(2021, time.July, 9, 18, 56, 3, 0, time.UTC),
+		}, true, time.Unix(int64(1623437763), 0)},
 	}
 
 	for i, tc := range testCases {
 		// Fixing the jwt.TimeFunc at 2021-01-06 05:16:09 +0000 UTC to
 		// ensure that the license JWT doesn't expire ever.
 		licInfo, err := lv.Verify(tc.lic, jwt.ParseOption(jwt.WithClock(jwt.ClockFunc(func() time.Time {
-			return time.Unix(int64(1609910169), 0)
+			return tc.iat
 		}))))
 		if err != nil && tc.shouldPass {
 			t.Fatalf("%d: Expected license to pass verification but failed with %s", i+1, err)


### PR DESCRIPTION
Trial licenses will have the Account ID as 0.
Added a new test to cover this.