### PR TITLE
fix the {a...aa} 

### DIFF
--- a/ellipses/ellipses.go
+++ b/ellipses/ellipses.go
@@ -54,24 +54,13 @@ func parseEllipsesRange(pattern string) (seq []string, err error) {
 		return nil, errors.New("Invalid argument")
 	}
 
-	var hexadecimal bool
-	var start, end uint64
-	if start, err = strconv.ParseUint(ellipsesRange[0], 10, 64); err != nil {
-		// Look for hexadecimal conversions if any.
-		start, err = strconv.ParseUint(ellipsesRange[0], 16, 64)
-		if err != nil {
-			return nil, err
-		}
-		hexadecimal = true
+	var start, end int
+	if start, err = strconv.Atoi(ellipsesRange[0]); err != nil {
+		return nil, err
 	}
 
-	if end, err = strconv.ParseUint(ellipsesRange[1], 10, 64); err != nil {
-		// Look for hexadecimal conversions if any.
-		end, err = strconv.ParseUint(ellipsesRange[1], 16, 64)
-		if err != nil {
-			return nil, err
-		}
-		hexadecimal = true
+	if end, err = strconv.Atoi(ellipsesRange[1]); err != nil {
+		return nil, err
 	}
 
 	if start > end {
@@ -80,17 +69,9 @@ func parseEllipsesRange(pattern string) (seq []string, err error) {
 
 	for i := start; i <= end; i++ {
 		if strings.HasPrefix(ellipsesRange[0], "0") && len(ellipsesRange[0]) > 1 || strings.HasPrefix(ellipsesRange[1], "0") {
-			if hexadecimal {
-				seq = append(seq, fmt.Sprintf(fmt.Sprintf("%%0%dx", len(ellipsesRange[1])), i))
-			} else {
-				seq = append(seq, fmt.Sprintf(fmt.Sprintf("%%0%dd", len(ellipsesRange[1])), i))
-			}
+			seq = append(seq, fmt.Sprintf(fmt.Sprintf("%%0%dd", len(ellipsesRange[1])), i))
 		} else {
-			if hexadecimal {
-				seq = append(seq, fmt.Sprintf("%x", i))
-			} else {
-				seq = append(seq, fmt.Sprintf("%d", i))
-			}
+			seq = append(seq, fmt.Sprintf("%d", i))
 		}
 	}
 


### PR DESCRIPTION
i fixed the parse /data{a...aa} to return a error
until now it returned 
[[{data  [a b c d e f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f 40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 54 55 56 57 58 59 5a 5b 5c 5d 5e 5f 60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 71 72 73 74 75 76 77 78 79 7a 7b 7c 7d 7e 7f 80 81 82 83 84 85 86 87 88 89 8a 8b 8c 8d 8e 8f 90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aa]}]] <nil>

and in minio it created a lot of folders and the server failed because the corrupted folder names 