### PR TITLE
console: Protect access to theme map

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -41,93 +41,93 @@ var (
 
 	// Print prints a message.
 	Print = func(data ...interface{}) {
-		consolePrint("Print", Theme["Print"], data...)
+		consolePrint("Print", getThemeColor("Print"), data...)
 	}
 
 	// PrintC prints a message with color.
 	PrintC = func(data ...interface{}) {
-		consolePrint("PrintC", Theme["PrintC"], data...)
+		consolePrint("PrintC", getThemeColor("PrintC"), data...)
 	}
 
 	// Printf prints a formatted message.
 	Printf = func(format string, data ...interface{}) {
-		consolePrintf("Print", Theme["Print"], format, data...)
+		consolePrintf("Print", getThemeColor("Print"), format, data...)
 	}
 
 	// Println prints a message with a newline.
 	Println = func(data ...interface{}) {
-		consolePrintln("Print", Theme["Print"], data...)
+		consolePrintln("Print", getThemeColor("Print"), data...)
 	}
 
 	// Fatal print a error message and exit.
 	Fatal = func(data ...interface{}) {
-		consolePrint("Fatal", Theme["Fatal"], data...)
+		consolePrint("Fatal", getThemeColor("Fatal"), data...)
 		os.Exit(1)
 	}
 
 	// Fatalf print a error message with a format specified and exit.
 	Fatalf = func(format string, data ...interface{}) {
-		consolePrintf("Fatal", Theme["Fatal"], format, data...)
+		consolePrintf("Fatal", getThemeColor("Fatal"), format, data...)
 		os.Exit(1)
 	}
 
 	// Fatalln print a error message with a new line and exit.
 	Fatalln = func(data ...interface{}) {
-		consolePrintln("Fatal", Theme["Fatal"], data...)
+		consolePrintln("Fatal", getThemeColor("Fatal"), data...)
 		os.Exit(1)
 	}
 
 	// Error prints a error message.
 	Error = func(data ...interface{}) {
-		consolePrint("Error", Theme["Error"], data...)
+		consolePrint("Error", getThemeColor("Error"), data...)
 	}
 
 	// Errorf print a error message with a format specified.
 	Errorf = func(format string, data ...interface{}) {
-		consolePrintf("Error", Theme["Error"], format, data...)
+		consolePrintf("Error", getThemeColor("Error"), format, data...)
 	}
 
 	// Errorln prints a error message with a new line.
 	Errorln = func(data ...interface{}) {
-		consolePrintln("Error", Theme["Error"], data...)
+		consolePrintln("Error", getThemeColor("Error"), data...)
 	}
 
 	// Info prints a informational message.
 	Info = func(data ...interface{}) {
-		consolePrint("Info", Theme["Info"], data...)
+		consolePrint("Info", getThemeColor("Info"), data...)
 	}
 
 	// Infof prints a informational message in custom format.
 	Infof = func(format string, data ...interface{}) {
-		consolePrintf("Info", Theme["Info"], format, data...)
+		consolePrintf("Info", getThemeColor("Info"), format, data...)
 	}
 
 	// Infoln prints a informational message with a new line.
 	Infoln = func(data ...interface{}) {
-		consolePrintln("Info", Theme["Info"], data...)
+		consolePrintln("Info", getThemeColor("Info"), data...)
 	}
 
 	// Debug prints a debug message without a new line
 	// Debug prints a debug message.
 	Debug = func(data ...interface{}) {
-		consolePrint("Debug", Theme["Debug"], data...)
+		consolePrint("Debug", getThemeColor("Debug"), data...)
 	}
 
 	// Debugf prints a debug message with a new line.
 	Debugf = func(format string, data ...interface{}) {
-		consolePrintf("Debug", Theme["Debug"], format, data...)
+		consolePrintf("Debug", getThemeColor("Debug"), format, data...)
 	}
 
 	// Debugln prints a debug message with a new line.
 	Debugln = func(data ...interface{}) {
-		consolePrintln("Debug", Theme["Debug"], data...)
+		consolePrintln("Debug", getThemeColor("Debug"), data...)
 	}
 
 	// Colorize prints message in a colorized form, dictated by the corresponding tag argument.
 	Colorize = func(tag string, data interface{}) string {
 		if isatty.IsTerminal(os.Stdout.Fd()) {
-			colorized, ok := Theme[tag]
-			if ok {
+			colorized := getThemeColor(tag)
+			if colorized != nil {
 				return colorized.SprintFunc()(data)
 			} // else: No theme found. Return as string.
 		}
@@ -136,8 +136,8 @@ var (
 
 	// Eraseline Print in new line and adjust to top so that we don't print over the ongoing progress bar.
 	Eraseline = func() {
-		consolePrintf("Print", Theme["Print"], "%c[2K\n", 27)
-		consolePrintf("Print", Theme["Print"], "%c[A", 27)
+		consolePrintf("Print", getThemeColor("Print"), "%c[2K\n", 27)
+		consolePrintf("Print", getThemeColor("Print"), "%c[A", 27)
 	}
 )
 

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -25,8 +25,8 @@ import (
 
 func TestSetColor(t *testing.T) {
 	SetColor("unknown", color.New(color.FgWhite))
-	_, ok := Theme["unknown"]
-	if !ok {
+	cl := getThemeColor("unknown")
+	if cl == nil {
 		t.Fatal("missing theme")
 	}
 }

--- a/console/themes.go
+++ b/console/themes.go
@@ -17,11 +17,15 @@
 
 package console
 
-import "github.com/fatih/color"
+import (
+	"sync"
+
+	"github.com/fatih/color"
+)
 
 var (
 	// Theme contains default color mapping.
-	Theme = map[string]*color.Color{
+	theme = map[string]*color.Color{
 		"Debug":  color.New(color.FgWhite, color.Faint, color.Italic),
 		"Fatal":  color.New(color.FgRed, color.Italic, color.Bold),
 		"Error":  color.New(color.FgYellow, color.Italic),
@@ -30,7 +34,21 @@ var (
 		"PrintB": color.New(color.FgBlue, color.Bold),
 		"PrintC": color.New(color.FgGreen, color.Bold),
 	}
+
+	themeMu sync.Mutex
 )
+
+func getThemeColor(tag string) *color.Color {
+	themeMu.Lock()
+	defer themeMu.Unlock()
+	return theme[tag]
+}
+
+func setThemeColor(tag string, cl *color.Color) {
+	themeMu.Lock()
+	defer themeMu.Unlock()
+	theme[tag] = cl
+}
 
 // SetColorOff disables coloring for the entire session.
 func SetColorOff() {
@@ -48,8 +66,6 @@ func SetColorOn() {
 
 // SetColor sets a color for a particular tag.
 func SetColor(tag string, cl *color.Color) {
-	privateMutex.Lock()
-	defer privateMutex.Unlock()
 	// add new theme
-	Theme[tag] = cl
+	setThemeColor(tag, cl)
 }


### PR DESCRIPTION
To fix the following crash:

```
fatal error: concurrent map read and map write

goroutine 98 [running]:
runtime.throw({0x4b8b456, 0x1e})
	runtime/panic.go:1198 +0x71 fp=0xc000113db0 sp=0xc000113d80
pc=0x4039871
runtime.mapaccess2_faststr(0x10, 0xc00006db00, {0x4b66bed, 0x5})
	runtime/map_faststr.go:116 +0x3d4 fp=0xc000113e18
sp=0xc000113db0 pc=0x4016d54
github.com/minio/pkg/console.glob..func17({0x4b66bed, 0x5}, {0x49f7dc0,
0xc00052a2c0})
	github.com/minio/pkg@v1.0.10/console/console.go:129 +0xad
fp=0xc000113e78 sp=0xc000113e18 pc=0x412566d
github.com/minio/mc/cmd.greenText({0xc0002091b8, 0x11})
	github.com/minio/mc/cmd/admin-subnet-health.go:162 +0x8b
fp=0xc000113eb0 sp=0xc000113e78 pc=0x489818b
github.com/minio/mc/cmd.fetchServerHealthInfo.func1.1({0x4b6fe33, 0xd},
{0x4cc7fe8, 0x1}, 0x0)
	github.com/minio/mc/cmd/admin-subnet-health.go:380 +0xb9
fp=0xc000113f70 sp=0xc000113eb0 pc=0x4950059
github.com/minio/mc/cmd.fetchServerHealthInfo.func1.3()
	github.com/minio/mc/cmd/admin-subnet-health.go:403 +0xb8
fp=0xc000113fe0 sp=0xc000113f70 pc=0x489b398
runtime.goexit()
	runtime/asm_amd64.s:1581 +0x1 fp=0xc000113fe8 sp=0xc000113fe0
pc=0x406d261
created by github.com/minio/mc/cmd.fetchServerHealthInfo.func1
	github.com/minio/mc/cmd/admin-subnet-health.go:394 +0x1bd

```