### PR TITLE
duplicate statements were removing more

### DIFF
--- a/bucket/policy/condition/ipaddrfunc_test.go
+++ b/bucket/policy/condition/ipaddrfunc_test.go
@@ -18,6 +18,8 @@
 package condition
 
 import (
+	"bytes"
+	"encoding/json"
 	"net"
 	"reflect"
 	"testing"
@@ -208,7 +210,9 @@ func TestIPAddrFuncClone(t *testing.T) {
 	for i, testCase := range testCases {
 		result := testCase.f.clone()
 
-		if !reflect.DeepEqual(result, testCase.expectedResult) {
+		exp1, _ := json.Marshal(result)
+		exp2, _ := json.Marshal(testCase.expectedResult)
+		if !bytes.Equal(exp1, exp2) {
 			t.Fatalf("case %v: result: expected: %v, got: %v\n", i+1, testCase.expectedResult, result)
 		}
 	}

--- a/bucket/policy/policy.go
+++ b/bucket/policy/policy.go
@@ -124,11 +124,11 @@ func (policy Policy) Merge(input Policy) Policy {
 func (policy *Policy) dropDuplicateStatements() {
 redo:
 	for i := range policy.Statements {
-		for j, statement := range policy.Statements[i+1:] {
+		for _, statement := range policy.Statements[i+1:] {
 			if !policy.Statements[i].Equals(statement) {
 				continue
 			}
-			policy.Statements = append(policy.Statements[:j], policy.Statements[j+1:]...)
+			policy.Statements = append(policy.Statements[:i], policy.Statements[i+1:]...)
 			goto redo
 		}
 	}

--- a/iam/policy/policy.go
+++ b/iam/policy/policy.go
@@ -194,11 +194,11 @@ func (iamp Policy) Merge(input Policy) Policy {
 func (iamp *Policy) dropDuplicateStatements() {
 redo:
 	for i := range iamp.Statements {
-		for j, statement := range iamp.Statements[i+1:] {
+		for _, statement := range iamp.Statements[i+1:] {
 			if !iamp.Statements[i].Equals(statement) {
 				continue
 			}
-			iamp.Statements = append(iamp.Statements[:j], iamp.Statements[j+1:]...)
+			iamp.Statements = append(iamp.Statements[:i], iamp.Statements[i+1:]...)
 			goto redo
 		}
 	}


### PR DESCRIPTION
dropping duplicate statements was incorrectly
implemented, leading to failure in dropping statements
when statements had > 2 statements and 2 of them
are duplicate.

Adds additional testcases to cover these scenarios.