### PR TITLE
Add policy for getting subnet license

### DIFF
--- a/iam/policy/admin-action.go
+++ b/iam/policy/admin-action.go
@@ -72,6 +72,9 @@ const (
 	// ConfigUpdateAdminAction - allow MinIO config management
 	ConfigUpdateAdminAction = "admin:ConfigUpdate"
 
+	// GetSubnetLicenseAdminAction - allow retrieving subnet license
+	GetSubnetLicenseAdminAction = "admin:GetSubnetLicense"
+
 	// CreateUserAdminAction - allow creating MinIO user
 	CreateUserAdminAction = "admin:CreateUser"
 	// DeleteUserAdminAction - allow deleting MinIO user


### PR DESCRIPTION
name -> admin:GetSubnetLicense

This will be used by console to fetch the subnet license of a cluster
without the need of having full access to minio config.