### PR TITLE
certs: reduce reload time for symlinks to 15 min

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -187,7 +187,7 @@ func (m *Manager) watchSymlinks(certFile, keyFile string) {
 		select {
 		case <-m.ctx.Done():
 			return // Once stopped exits this routine.
-		case <-time.After(24 * time.Hour):
+		case <-time.After(15 * time.Minute):
 			certificate, err := m.loadX509KeyPair(certFile, keyFile)
 			if err != nil {
 				continue


### PR DESCRIPTION
This commit reduces the certificate reload time
window (for symlinks) to 15 min. Before, certificates
would have been reloaded every 24h - which can be
an issue when certificates are valid for less than 24h.

Now, certificates mounted as symlinks will be reloaded
after 15 minutes - which is on the one side frequent enough
to avoid expiry issues and on the other side rare enough
to not cause any noticeable I/O load.