### PR TITLE
Revert "Add policy for getting subnet license (#13)"

### DIFF
--- a/iam/policy/admin-action.go
+++ b/iam/policy/admin-action.go
@@ -72,9 +72,6 @@ const (
 	// ConfigUpdateAdminAction - allow MinIO config management
 	ConfigUpdateAdminAction = "admin:ConfigUpdate"
 
-	// GetSubnetLicenseAdminAction - allow retrieving subnet license
-	GetSubnetLicenseAdminAction = "admin:GetSubnetLicense"
-
 	// CreateUserAdminAction - allow creating MinIO user
 	CreateUserAdminAction = "admin:CreateUser"
 	// DeleteUserAdminAction - allow deleting MinIO user


### PR DESCRIPTION
This policy is not required as the concept of subnet license is going
to be replaced by cluster level api keys.

This reverts commit e71c4f6ea8372a1612da0f7887f513ead2f5f301.