### PR TITLE
Add pseudo-random reader

### DIFF
--- a/randreader/randreader.go
+++ b/randreader/randreader.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package randreader
+
+import (
+	"io"
+	"math/rand"
+	"time"
+)
+
+const bufferSize = 16 << 10
+
+// New returns an infinite reader that will return pseudo-random data.
+// Data should not be used for cryptographic functions.
+// A random time based seed is used.
+func New() io.Reader {
+	return NewSource(rand.NewSource(time.Now().UnixNano()))
+}
+
+// NewSource returns an infinite reader that will return pseudo-random data.
+// Data should not be used for cryptographic functions.
+// The data is seeded from the provided source.
+func NewSource(src rand.Source) io.Reader {
+	rng := rand.New(src)
+	rngFull := func(data []byte) {
+		_, err := io.ReadFull(rng, data)
+		if err != nil {
+			panic(err)
+		}
+	}
+	data := make([]byte, bufferSize)
+	rngFull(data)
+
+	return newXorBuffer(data, rand.New(src))
+}

--- a/randreader/rangreader_test.go
+++ b/randreader/rangreader_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package randreader
+
+import (
+	"io"
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkReader(b *testing.B) {
+	const size = 100000
+
+	var buf = make([]byte, size)
+	src := New()
+	b.SetBytes(size)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n, err := io.ReadFull(src, buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if n != size {
+			b.Fatalf("want read size %d, got %d", size, n)
+		}
+	}
+}
+
+func BenchmarkMathRand(b *testing.B) {
+	const size = 100000
+
+	var buf = make([]byte, size)
+	src := rand.New(rand.NewSource(0))
+	b.SetBytes(size)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n, err := io.ReadFull(src, buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if n != size {
+			b.Fatalf("want read size %d, got %d", size, n)
+		}
+	}
+}

--- a/randreader/xor.go
+++ b/randreader/xor.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package randreader
+
+import (
+	"errors"
+	"math/rand"
+)
+
+type xorBuffer struct {
+	data []byte
+	// left aliases the data at the current read position.
+	left []byte
+
+	tmp [16]byte
+	rng *rand.Rand
+}
+
+func newXorBuffer(data []byte, rng *rand.Rand) *xorBuffer {
+	return &xorBuffer{
+		data: data,
+		left: data,
+		rng:  rng,
+	}
+}
+
+func (c *xorBuffer) Read(p []byte) (n int, err error) {
+	if len(c.data) == 0 {
+		return 0, errors.New("circularBuffer: no data")
+	}
+	for len(p) > 0 {
+		if len(c.left) == 0 {
+			// Read 16 random bytes for xor
+			c.rng.Read(c.tmp[:])
+			xorSlice(c.tmp[:], c.data)
+			c.left = c.data
+		}
+
+		// Make sure we don't overread.
+		toDo := c.left
+		copied := copy(p, toDo)
+		// Assign remaining back to c.left
+		c.left = toDo[copied:]
+		p = p[copied:]
+		n += copied
+	}
+	return n, nil
+}

--- a/randreader/xor_amd64.go
+++ b/randreader/xor_amd64.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !noasm && !appengine && !gccgo
+// +build !noasm,!appengine,!gccgo
+
+package randreader
+
+//go:noescape
+func xorSlice(rand, out []byte)

--- a/randreader/xor_amd64.s
+++ b/randreader/xor_amd64.s
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//+build !noasm
+//+build !appengine
+//+build !gccgo
+
+// func xorSlice(rand, out []byte)
+TEXT ·xorSlice(SB), 7, $0
+	MOVQ  rand+0(FP), SI   // SI: &rand
+	MOVQ  out+24(FP), DX   // DX: &out
+	MOVQ  out+32(FP), R9   // R9: len(out)
+	MOVOU (SI), X0         // in[x]
+	SHRQ  $6, R9           // len(in) / 64
+	CMPQ  R9, $0
+	JEQ   done_xor_sse2_64
+
+loopback_xor_sse2_64:
+	MOVOU (DX), X1             // out[x]
+	MOVOU 16(DX), X3           // out[x]
+	MOVOU 32(DX), X5           // out[x]
+	MOVOU 48(DX), X7           // out[x]
+	PXOR  X0, X1
+	PXOR  X0, X3
+	PXOR  X0, X5
+	PXOR  X0, X7
+	MOVOU X1, (DX)
+	MOVOU X3, 16(DX)
+	MOVOU X5, 32(DX)
+	MOVOU X7, 48(DX)
+	ADDQ  $64, DX              // out+=64
+	SUBQ  $1, R9
+	JNZ   loopback_xor_sse2_64
+
+done_xor_sse2_64:
+	RET

--- a/randreader/xor_noasm.go
+++ b/randreader/xor_noasm.go
@@ -1,0 +1,40 @@
+//go:build !amd64 || noasm || appengine || gccgo
+// +build !amd64 noasm appengine gccgo
+
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package randreader
+
+import "encoding/binary"
+
+func xorSlice(rand, out []byte) {
+	var a0, a1 uint64
+	a0 = binary.LittleEndian.Uint64(rand)
+	a1 = binary.LittleEndian.Uint64(rand[8:])
+	for len(out) >= 32 {
+		v0 := binary.LittleEndian.Uint64(out[:]) ^ a0
+		v1 := binary.LittleEndian.Uint64(out[8:]) ^ a1
+		v2 := binary.LittleEndian.Uint64(out[16:]) ^ a0
+		v3 := binary.LittleEndian.Uint64(out[24:]) ^ a1
+		binary.LittleEndian.PutUint64(out[:], v0)
+		binary.LittleEndian.PutUint64(out[8:], v1)
+		binary.LittleEndian.PutUint64(out[16:], v2)
+		binary.LittleEndian.PutUint64(out[24:], v3)
+		out = out[32:]
+	}
+}


### PR DESCRIPTION
Provides infinite stream of pseudorandom data.

```
math/rand:
BenchmarkMathRand-32               20776             58177 ns/op        1718.88 MB/s           0 B/op          0 allocs/op

This:
BenchmarkReader-32                385144              2967 ns/op        33702.78 MB/s          0 B/op          0 allocs/op

This, no asm:
BenchmarkReader-32                197226              5938 ns/op        16839.56 MB/s          0 B/op          0 allocs/op
```

I have tested the output is incompressible and that asm and no-asm produces the same output.