### PR TITLE
Consider SID in merging and equality of policy statements

### DIFF
--- a/bucket/policy/policy.go
+++ b/bucket/policy/policy.go
@@ -112,10 +112,14 @@ func (policy Policy) Merge(input Policy) Policy {
 		mergedPolicy.Version = input.Version
 	}
 	for _, st := range policy.Statements {
-		mergedPolicy.Statements = append(mergedPolicy.Statements, st.Clone())
+		var newSt Statement = st.Clone()
+		newSt.SID = st.SID
+		mergedPolicy.Statements = append(mergedPolicy.Statements, newSt)
 	}
 	for _, st := range input.Statements {
-		mergedPolicy.Statements = append(mergedPolicy.Statements, st.Clone())
+		var newSt Statement = st.Clone()
+		newSt.SID = st.SID
+		mergedPolicy.Statements = append(mergedPolicy.Statements, newSt)
 	}
 	mergedPolicy.dropDuplicateStatements()
 	return mergedPolicy

--- a/bucket/policy/statement.go
+++ b/bucket/policy/statement.go
@@ -36,6 +36,9 @@ type Statement struct {
 
 // Equals checks if two statements are equal
 func (statement Statement) Equals(st Statement) bool {
+	if statement.SID != "" && statement.SID == st.SID {
+		return true
+	}
 	if statement.Effect != st.Effect {
 		return false
 	}

--- a/iam/policy/policy.go
+++ b/iam/policy/policy.go
@@ -223,10 +223,14 @@ func (iamp Policy) Merge(input Policy) Policy {
 		mergedPolicy.Version = input.Version
 	}
 	for _, st := range iamp.Statements {
-		mergedPolicy.Statements = append(mergedPolicy.Statements, st.Clone())
+		var newSt Statement = st.Clone()
+		newSt.SID = st.SID
+		mergedPolicy.Statements = append(mergedPolicy.Statements, newSt)
 	}
 	for _, st := range input.Statements {
-		mergedPolicy.Statements = append(mergedPolicy.Statements, st.Clone())
+		var newSt Statement = st.Clone()
+		newSt.SID = st.SID
+		mergedPolicy.Statements = append(mergedPolicy.Statements, newSt)
 	}
 	mergedPolicy.dropDuplicateStatements()
 	return mergedPolicy

--- a/iam/policy/statement.go
+++ b/iam/policy/statement.go
@@ -132,6 +132,9 @@ func (statement Statement) Validate() error {
 
 // Equals checks if two statements are equal
 func (statement Statement) Equals(st Statement) bool {
+	if statement.SID != "" && statement.SID == st.SID {
+		return true
+	}
 	if statement.Effect != st.Effect {
 		return false
 	}


### PR DESCRIPTION
This does 2 things:
- Adds SID to cloned statements in **bucket** and **iam** policy merge methods
- Considers SID in checking equality of policy statements

Should solve [minio#13905](https://github.com/minio/minio/issues/13905)