### PR TITLE
Increase lookupEnv timeout to 6.5 seconds

### DIFF
--- a/env/web_env.go
+++ b/env/web_env.go
@@ -90,7 +90,7 @@ func getEnvValueFromHTTP(urlStr, envKey string) (string, string, string, error) 
 		return "", "", "", err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 6.5*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, envURL+"?key="+envKey, nil)

--- a/env/web_env.go
+++ b/env/web_env.go
@@ -90,7 +90,7 @@ func getEnvValueFromHTTP(urlStr, envKey string) (string, string, string, error) 
 		return "", "", "", err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, envURL+"?key="+envKey, nil)

--- a/env/web_env.go
+++ b/env/web_env.go
@@ -92,7 +92,7 @@ func getEnvValueFromHTTP(urlStr, envKey string) (string, string, string, error) 
 
 	// Adding a timeout of 6.5 seconds to deal with k3s slow dns resolution caused in turn by
 	// CoreDNS 6 second default timeout.
-	ctx, cancel := context.WithTimeout(context.Background(), 6.5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 6500*time.Millisecond)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, envURL+"?key="+envKey, nil)

--- a/env/web_env.go
+++ b/env/web_env.go
@@ -90,7 +90,7 @@ func getEnvValueFromHTTP(urlStr, envKey string) (string, string, string, error) 
 		return "", "", "", err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, envURL+"?key="+envKey, nil)

--- a/env/web_env.go
+++ b/env/web_env.go
@@ -90,6 +90,8 @@ func getEnvValueFromHTTP(urlStr, envKey string) (string, string, string, error) 
 		return "", "", "", err
 	}
 
+	// Adding a timeout of 6.5 seconds to deal with k3s slow dns resolution caused in turn by
+	// CoreDNS 6 second default timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), 6.5*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
On certain environments, 3 second timeout is too small causing MinIO to panic and fail complaining the environment could't be resolved


Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>