### PR TITLE
implement usage of ExistingObjectTag in GetObjectAction

### DIFF
--- a/bucket/policy/action.go
+++ b/bucket/policy/action.go
@@ -336,6 +336,7 @@ func createActionConditionKeyMap() map[Action]condition.KeySet {
 			append([]condition.Key{
 				condition.S3XAmzServerSideEncryption.ToKey(),
 				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
 			}, commonKeys...)...),
 
 		HeadBucketAction: condition.NewKeySet(commonKeys...),
@@ -374,6 +375,7 @@ func createActionConditionKeyMap() map[Action]condition.KeySet {
 				condition.S3ObjectLockRetainUntilDate.ToKey(),
 				condition.S3ObjectLockMode.ToKey(),
 				condition.S3ObjectLockLegalHold.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
 			}, commonKeys...)...),
 
 		// https://docs.aws.amazon.com/AmazonS3/latest/dev/list_amazons3.html

--- a/bucket/policy/condition/key_test.go
+++ b/bucket/policy/condition/key_test.go
@@ -39,6 +39,9 @@ func TestKeyIsValid(t *testing.T) {
 		{S3MaxKeys.ToKey(), true},
 		{AWSReferer.ToKey(), true},
 		{AWSSourceIP.ToKey(), true},
+		{ExistingObjectTag.ToKey(), true},
+		{RequestObjectTagKeys.ToKey(), false},
+		{RequestObjectTag.ToKey(), false},
 		{Key{name: "foo"}, false},
 	}
 

--- a/bucket/policy/condition/keyname.go
+++ b/bucket/policy/condition/keyname.go
@@ -249,6 +249,7 @@ var AllSupportedKeys = append([]KeyName{
 	AWSUsername,
 	LDAPUser,
 	LDAPUsername,
+	ExistingObjectTag,
 	// Add new supported condition keys.
 }, JWTKeys...)
 
@@ -269,6 +270,7 @@ var CommonKeys = append([]KeyName{
 	AWSUsername,
 	LDAPUser,
 	LDAPUsername,
+	ExistingObjectTag,
 }, JWTKeys...)
 
 // AllSupportedAdminKeys - is list of all admin supported keys.


### PR DESCRIPTION
Code update of pkg minio to use running ExistingObjectTag in 'Get Object Action' as define in S3 iam policy declaration.

The code is also ready to be push on the minio/minio code when theses modications are accepted (if it was :) )

