### PR TITLE
Add IAM policies  to control access to KES APIs

### DIFF
--- a/iam/policy/actionset.go
+++ b/iam/policy/actionset.go
@@ -132,6 +132,14 @@ func (actionSet ActionSet) ToAdminSlice() []AdminAction {
 	return actions
 }
 
+// ToKMSSlice - returns slice of kms actions from the action set.
+func (actionSet ActionSet) ToKMSSlice() (actions []KMSAction) {
+	for action := range actionSet {
+		actions = append(actions, KMSAction(action))
+	}
+	return actions
+}
+
 // UnmarshalJSON - decodes JSON data to ActionSet.
 func (actionSet *ActionSet) UnmarshalJSON(data []byte) error {
 	var sset set.StringSet
@@ -156,6 +164,16 @@ func (actionSet ActionSet) ValidateAdmin() error {
 	for _, action := range actionSet.ToAdminSlice() {
 		if !action.IsValid() {
 			return Errorf("unsupported admin action '%v'", action)
+		}
+	}
+	return nil
+}
+
+// ValidateKMS checks if all actions are valid KMS actions
+func (actionSet ActionSet) ValidateKMS() error {
+	for _, action := range actionSet.ToKMSSlice() {
+		if !action.IsValid() {
+			return Errorf("unsupported KMS action '%v'", action)
 		}
 	}
 	return nil

--- a/iam/policy/kms-action.go
+++ b/iam/policy/kms-action.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package iampolicy
+
+// KMSAction - KMS policy action.
+type KMSAction string
+
+const (
+	// KMSCreateKeyAction - allow creating a new KMS master key
+	KMSCreateKeyAction = "kms:KMSCreateKey"
+	// KMSDeleteKeyAction - allow deleting a KMS master key
+	KMSDeleteKeyAction = "kms:KMSDeleteKey"
+	// KMSListKeysAction - allow getting list of KMS keys
+	KMSListKeysAction = "kms:KMSListKeys"
+	// KMSImportKeyAction - allow importing KMS key
+	KMSImportKeyAction = "kms:KMSImportKey"
+	// KMSDescribePolicyAction - allow getting KMS policy
+	KMSDescribePolicyAction = "kms:KMSDescribePolicy"
+	// KMSAssignPolicyAction - allow assigning an identity to a KMS policy
+	KMSAssignPolicyAction = "kms:KMSAssignPolicy"
+	// KMSDeletePolicyAction - allow deleting a policy
+	KMSDeletePolicyAction = "kms:KMSDeletePolicy"
+	// KMSSetPolicyAction - allow creating or updating a policy
+	KMSSetPolicyAction = "kms:KMSSetPolicy"
+	// KMSGetPolicyAction - allow getting a policy
+	KMSGetPolicyAction = "kms:KMSGetPolicy"
+	// KMSListPoliciesAction - allow getting list of KMS policies
+	KMSListPoliciesAction = "kms:KMSListPolicies"
+	// KMSDescribeIdentityAction - allow getting KMS identity
+	KMSDescribeIdentityAction = "kms:KMSDescribeIdentity"
+	// KMSDescribeSelfIdentityAction - allow getting self KMS identity
+	KMSDescribeSelfIdentityAction = "kms:KMSDescribeSelfIdentity"
+	// KMSDeleteIdentityAction - allow deleting a policy
+	KMSDeleteIdentityAction = "kms:KMSDeleteIdentity"
+	// KMSListIdentitiesAction - allow getting list of KMS identities
+	KMSListIdentitiesAction = "kms:KMSListIdentities"
+	// KMSKeyStatusAction - allow getting KMS key status
+	KMSKeyStatusAction = "kms:KMSKeyStatus"
+	// KMSStatusAction - allow getting KMS status
+	KMSStatusAction = "kms:KMSStatus"
+	// AllKMSActions - provides all admin permissions
+	AllKMSActions = "kms:*"
+)
+
+// List of all supported admin actions.
+var supportedKMSActions = map[KMSAction]struct{}{
+	KMSCreateKeyAction:            {},
+	KMSDeleteKeyAction:            {},
+	KMSListKeysAction:             {},
+	KMSImportKeyAction:            {},
+	KMSDescribePolicyAction:       {},
+	KMSAssignPolicyAction:         {},
+	KMSDeletePolicyAction:         {},
+	KMSSetPolicyAction:            {},
+	KMSGetPolicyAction:            {},
+	KMSListPoliciesAction:         {},
+	KMSDescribeIdentityAction:     {},
+	KMSDescribeSelfIdentityAction: {},
+	KMSDeleteIdentityAction:       {},
+	KMSListIdentitiesAction:       {},
+	KMSKeyStatusAction:            {},
+	AllKMSActions:                 {},
+}
+
+// IsValid - checks if action is valid or not.
+func (action KMSAction) IsValid() bool {
+	_, ok := supportedKMSActions[action]
+	return ok
+}

--- a/iam/policy/kms-action.go
+++ b/iam/policy/kms-action.go
@@ -22,37 +22,37 @@ type KMSAction string
 
 const (
 	// KMSCreateKeyAction - allow creating a new KMS master key
-	KMSCreateKeyAction = "kms:KMSCreateKey"
+	KMSCreateKeyAction = "kms:CreateKey"
 	// KMSDeleteKeyAction - allow deleting a KMS master key
-	KMSDeleteKeyAction = "kms:KMSDeleteKey"
+	KMSDeleteKeyAction = "kms:DeleteKey"
 	// KMSListKeysAction - allow getting list of KMS keys
-	KMSListKeysAction = "kms:KMSListKeys"
+	KMSListKeysAction = "kms:ListKeys"
 	// KMSImportKeyAction - allow importing KMS key
-	KMSImportKeyAction = "kms:KMSImportKey"
+	KMSImportKeyAction = "kms:ImportKey"
 	// KMSDescribePolicyAction - allow getting KMS policy
-	KMSDescribePolicyAction = "kms:KMSDescribePolicy"
+	KMSDescribePolicyAction = "kms:DescribePolicy"
 	// KMSAssignPolicyAction - allow assigning an identity to a KMS policy
-	KMSAssignPolicyAction = "kms:KMSAssignPolicy"
+	KMSAssignPolicyAction = "kms:AssignPolicy"
 	// KMSDeletePolicyAction - allow deleting a policy
-	KMSDeletePolicyAction = "kms:KMSDeletePolicy"
+	KMSDeletePolicyAction = "kms:DeletePolicy"
 	// KMSSetPolicyAction - allow creating or updating a policy
-	KMSSetPolicyAction = "kms:KMSSetPolicy"
+	KMSSetPolicyAction = "kms:SetPolicy"
 	// KMSGetPolicyAction - allow getting a policy
-	KMSGetPolicyAction = "kms:KMSGetPolicy"
+	KMSGetPolicyAction = "kms:GetPolicy"
 	// KMSListPoliciesAction - allow getting list of KMS policies
-	KMSListPoliciesAction = "kms:KMSListPolicies"
+	KMSListPoliciesAction = "kms:ListPolicies"
 	// KMSDescribeIdentityAction - allow getting KMS identity
-	KMSDescribeIdentityAction = "kms:KMSDescribeIdentity"
+	KMSDescribeIdentityAction = "kms:DescribeIdentity"
 	// KMSDescribeSelfIdentityAction - allow getting self KMS identity
-	KMSDescribeSelfIdentityAction = "kms:KMSDescribeSelfIdentity"
+	KMSDescribeSelfIdentityAction = "kms:DescribeSelfIdentity"
 	// KMSDeleteIdentityAction - allow deleting a policy
-	KMSDeleteIdentityAction = "kms:KMSDeleteIdentity"
+	KMSDeleteIdentityAction = "kms:DeleteIdentity"
 	// KMSListIdentitiesAction - allow getting list of KMS identities
-	KMSListIdentitiesAction = "kms:KMSListIdentities"
+	KMSListIdentitiesAction = "kms:ListIdentities"
 	// KMSKeyStatusAction - allow getting KMS key status
-	KMSKeyStatusAction = "kms:KMSKeyStatus"
+	KMSKeyStatusAction = "kms:KeyStatus"
 	// KMSStatusAction - allow getting KMS status
-	KMSStatusAction = "kms:KMSStatus"
+	KMSStatusAction = "kms:Status"
 	// AllKMSActions - provides all admin permissions
 	AllKMSActions = "kms:*"
 )

--- a/iam/policy/statement.go
+++ b/iam/policy/statement.go
@@ -71,6 +71,15 @@ func (statement Statement) isAdmin() bool {
 	return false
 }
 
+func (statement Statement) isKMS() bool {
+	for action := range statement.Actions {
+		if KMSAction(action).IsValid() {
+			return true
+		}
+	}
+	return false
+}
+
 // isValid - checks whether statement is valid or not.
 func (statement Statement) isValid() error {
 	if !statement.Effect.IsValid() {
@@ -91,6 +100,13 @@ func (statement Statement) isValid() error {
 			if !keyDiff.IsEmpty() {
 				return Errorf("unsupported condition keys '%v' used for action '%v'", keyDiff, action)
 			}
+		}
+		return nil
+	}
+
+	if statement.isKMS() {
+		if err := statement.Actions.ValidateKMS(); err != nil {
+			return err
 		}
 		return nil
 	}


### PR DESCRIPTION
Adds IAM policies to control access to minio handlers that will communicate with KES.

The handlers will be added in minio in another PR in which i'm currently working on.

Please let me know if there are more places where i need to make changes since this is the first time i work with policies.

Closes: https://github.com/miniohq/engineering/issues/924