### PR TITLE
Add LDAP SRV Record lookup support

### DIFF
--- a/ldap/validation_test.go
+++ b/ldap/validation_test.go
@@ -43,7 +43,7 @@ func TestConfigValidator(t *testing.T) {
 				v := Config{Enabled: true}
 				return v
 			}(),
-			expectedResult: ConnectivityError,
+			expectedResult: ConnectionParamMisconfigured,
 		},
 		{
 			cfg: func() Config {
@@ -243,6 +243,22 @@ func TestConfigValidator(t *testing.T) {
 				return v
 			}(),
 			expectedResult: UserSearchParamsMisconfigured,
+		},
+		{
+			cfg: func() Config {
+				v := Config{Enabled: true}
+				v.ServerAddr = ldapServer
+				v.SRVRecordName = "thingy" // Bad SRV record name.
+				v.ServerInsecure = true
+				v.LookupBindDN = "cn=admin,dc=min,dc=io"
+				v.LookupBindPassword = "admin"
+				v.UserDNSearchFilter = "(uid=%s)"
+				v.UserDNSearchBaseDistName = "dc=min,dc=io"
+				v.GroupSearchBaseDistName = "ou=swengg,dc=min,dc=io"
+				v.GroupSearchFilter = "(&(objectclass=groupofnames)(member=%d))"
+				return v
+			}(),
+			expectedResult: ConnectionParamMisconfigured,
 		},
 	}
 


### PR DESCRIPTION
Adds `SRVRecordName` configuration parameter and validation for it. The
value can be `ldaps`, `ldap` or the special value `on`. This value is
combined with the `ServerAddr` parameter to lookup a DNS SRV record for
finding target LDAP servers.

The SRV record name format is always `_service._proto.domainname`. For LDAP
`proto` value here is always `tcp`. The `service` value is usually
`ldap`, and sometimes `ldaps`. When `SRVRecordName` is set to `ldap` or
`ldaps`, this value is substituted for `service`. The `domainname` value
is given by the `ServerAddr` parameter.

When a different SRV record name needs to be given, set `SRVRecordName`
to the special value `on`, and set the `ServerAddr` to the full SRV
record name, e.g. `_ldapish._tcpish.myldapserver.com`.