### PR TITLE
Move Audit and Log structures from minio/internal/logger

### DIFF
--- a/logger/message/audit/entry.go
+++ b/logger/message/audit/entry.go
@@ -1,3 +1,20 @@
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package audit
 
 import "time"

--- a/logger/message/audit/entry.go
+++ b/logger/message/audit/entry.go
@@ -1,0 +1,46 @@
+package audit
+
+import "time"
+
+// ObjectVersion object version key/versionId
+type ObjectVersion struct {
+	ObjectName string `json:"objectName"`
+	VersionID  string `json:"versionId,omitempty"`
+}
+
+// Entry - audit entry logs.
+type Entry struct {
+	Version      string    `json:"version"`
+	DeploymentID string    `json:"deploymentid,omitempty"`
+	Time         time.Time `json:"time"`
+	Event        string    `json:"event"`
+	// deprecated replaced by 'Event', kept here for some
+	// time for backward compatibility with k8s Operator.
+	Trigger string `json:"trigger"`
+	API     struct {
+		Name            string          `json:"name,omitempty"`
+		Bucket          string          `json:"bucket,omitempty"`
+		Object          string          `json:"object,omitempty"`
+		Objects         []ObjectVersion `json:"objects,omitempty"`
+		Status          string          `json:"status,omitempty"`
+		StatusCode      int             `json:"statusCode,omitempty"`
+		InputBytes      int64           `json:"rx"`
+		OutputBytes     int64           `json:"tx"`
+		HeaderBytes     int64           `json:"txHeaders,omitempty"`
+		TimeToFirstByte string          `json:"timeToFirstByte,omitempty"`
+		TimeToResponse  string          `json:"timeToResponse,omitempty"`
+	} `json:"api"`
+	RemoteHost string                 `json:"remotehost,omitempty"`
+	RequestID  string                 `json:"requestID,omitempty"`
+	UserAgent  string                 `json:"userAgent,omitempty"`
+	ReqClaims  map[string]interface{} `json:"requestClaims,omitempty"`
+	ReqQuery   map[string]string      `json:"requestQuery,omitempty"`
+	ReqHeader  map[string]string      `json:"requestHeader,omitempty"`
+	RespHeader map[string]string      `json:"responseHeader,omitempty"`
+	Tags       map[string]interface{} `json:"tags,omitempty"`
+
+	AccessKey  string `json:"accessKey,omitempty"`
+	ParentUser string `json:"parentUser,omitempty"`
+
+	Error string `json:"error,omitempty"`
+}

--- a/logger/message/log/entry.go
+++ b/logger/message/log/entry.go
@@ -1,9 +1,10 @@
 package log
 
 import (
-	"github.com/minio/madmin-go/v2"
 	"strings"
 	"time"
+
+	"github.com/minio/madmin-go/v2"
 )
 
 // ObjectVersion object version key/versionId

--- a/logger/message/log/entry.go
+++ b/logger/message/log/entry.go
@@ -1,0 +1,71 @@
+package log
+
+import (
+	"github.com/minio/madmin-go/v2"
+	"strings"
+	"time"
+)
+
+// ObjectVersion object version key/versionId
+type ObjectVersion struct {
+	ObjectName string `json:"objectName"`
+	VersionID  string `json:"versionId,omitempty"`
+}
+
+// Args - defines the arguments for the API.
+type Args struct {
+	Bucket    string            `json:"bucket,omitempty"`
+	Object    string            `json:"object,omitempty"`
+	VersionID string            `json:"versionId,omitempty"`
+	Objects   []ObjectVersion   `json:"objects,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+// Trace - defines the trace.
+type Trace struct {
+	Message   string                 `json:"message,omitempty"`
+	Source    []string               `json:"source,omitempty"`
+	Variables map[string]interface{} `json:"variables,omitempty"`
+}
+
+// API - defines the api type and its args.
+type API struct {
+	Name string `json:"name,omitempty"`
+	Args *Args  `json:"args,omitempty"`
+}
+
+// Entry - defines fields and values of each log entry.
+type Entry struct {
+	DeploymentID string         `json:"deploymentid,omitempty"`
+	Level        string         `json:"level"`
+	LogKind      madmin.LogKind `json:"errKind"`
+	Time         time.Time      `json:"time"`
+	API          *API           `json:"api,omitempty"`
+	RemoteHost   string         `json:"remotehost,omitempty"`
+	Host         string         `json:"host,omitempty"`
+	RequestID    string         `json:"requestID,omitempty"`
+	UserAgent    string         `json:"userAgent,omitempty"`
+	Message      string         `json:"message,omitempty"`
+	Trace        *Trace         `json:"error,omitempty"`
+}
+
+// Info holds console log messages
+type Info struct {
+	Entry
+	ConsoleMsg string
+	NodeName   string `json:"node"`
+	Err        error  `json:"-"`
+}
+
+// Mask returns the mask based on the error level.
+func (l Info) Mask() uint64 {
+	return l.LogKind.LogMask().Mask()
+}
+
+// SendLog returns true if log pertains to node specified in args.
+func (l Info) SendLog(node string, logKind madmin.LogMask) bool {
+	if logKind.Contains(l.LogKind.LogMask()) {
+		return node == "" || strings.EqualFold(node, l.NodeName) && !l.Time.IsZero()
+	}
+	return false
+}

--- a/logger/message/log/entry.go
+++ b/logger/message/log/entry.go
@@ -1,3 +1,20 @@
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package log
 
 import (


### PR DESCRIPTION
Since we have a need to unmarshal the Audit log structure we are moving it to `pkg`

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>