### PR TITLE
Replace Policy.Merge() with MergePolicies()

### DIFF
--- a/bucket/policy/policy.go
+++ b/bucket/policy/policy.go
@@ -102,23 +102,20 @@ func (policy Policy) MarshalJSON() ([]byte, error) {
 	return json.Marshal(subPolicy(policy))
 }
 
-// Merge merges two policies documents and drop
-// duplicate statements if any.
-func (policy Policy) Merge(input Policy) Policy {
-	var mergedPolicy Policy
-	if policy.Version != "" {
-		mergedPolicy.Version = policy.Version
-	} else {
-		mergedPolicy.Version = input.Version
+// MergePolicies merges all the given policies into a single policy dropping any
+// duplicate statements.
+func MergePolicies(inputs ...Policy) Policy {
+	var merged Policy
+	for _, p := range inputs {
+		if merged.Version == "" {
+			merged.Version = p.Version
+		}
+		for _, st := range p.Statements {
+			merged.Statements = append(merged.Statements, st.Clone())
+		}
 	}
-	for _, st := range policy.Statements {
-		mergedPolicy.Statements = append(mergedPolicy.Statements, st.Clone())
-	}
-	for _, st := range input.Statements {
-		mergedPolicy.Statements = append(mergedPolicy.Statements, st.Clone())
-	}
-	mergedPolicy.dropDuplicateStatements()
-	return mergedPolicy
+	merged.dropDuplicateStatements()
+	return merged
 }
 
 func (policy *Policy) dropDuplicateStatements() {

--- a/bucket/policy/policy_test.go
+++ b/bucket/policy/policy_test.go
@@ -1225,20 +1225,19 @@ func TestPolicyMerge(t *testing.T) {
 			t.Fatalf("case %v: unexpected error: %v", i+1, err)
 		}
 
-		var clonedPolicy Policy
-		clonedPolicy = clonedPolicy.Merge(p)
+		mergedPolicy := MergePolicies(p)
 
-		j, err := json.Marshal(clonedPolicy)
+		j, err := json.Marshal(mergedPolicy)
 		if err != nil {
 			t.Fatalf("case %v: unexpected error: %v", i+1, err)
 		}
 
-		err = json.Unmarshal(j, &clonedPolicy)
+		err = json.Unmarshal(j, &mergedPolicy)
 		if err != nil {
 			t.Fatalf("case %v: unexpected error: %v", i+1, err)
 		}
 
-		if !clonedPolicy.Statements[0].Equals(p.Statements[0]) {
+		if !mergedPolicy.Statements[0].Equals(p.Statements[0]) {
 			t.Fatalf("case %v: different policy outcome", i+1)
 		}
 	}

--- a/iam/policy/policy.go
+++ b/iam/policy/policy.go
@@ -225,23 +225,20 @@ func (iamp Policy) isValid() error {
 	return nil
 }
 
-// Merge merges two policies documents and drop
-// duplicate statements if any.
-func (iamp Policy) Merge(input Policy) Policy {
-	var mergedPolicy Policy
-	if iamp.Version != "" {
-		mergedPolicy.Version = iamp.Version
-	} else {
-		mergedPolicy.Version = input.Version
+// MergePolicies merges all the given policies into a single policy dropping any
+// duplicate statements.
+func MergePolicies(inputs ...Policy) Policy {
+	var merged Policy
+	for _, p := range inputs {
+		if merged.Version == "" {
+			merged.Version = p.Version
+		}
+		for _, st := range p.Statements {
+			merged.Statements = append(merged.Statements, st.Clone())
+		}
 	}
-	for _, st := range iamp.Statements {
-		mergedPolicy.Statements = append(mergedPolicy.Statements, st.Clone())
-	}
-	for _, st := range input.Statements {
-		mergedPolicy.Statements = append(mergedPolicy.Statements, st.Clone())
-	}
-	mergedPolicy.dropDuplicateStatements()
-	return mergedPolicy
+	merged.dropDuplicateStatements()
+	return merged
 }
 
 func (iamp *Policy) dropDuplicateStatements() {


### PR DESCRIPTION
It is faster to merge multiple in a single pass than to merge policies pairwise. Also adds a test for MergePolicies.