### PR TITLE
fix: bucket matching for bucket policy resource

### DIFF
--- a/bucket/policy/resource_test.go
+++ b/bucket/policy/resource_test.go
@@ -209,6 +209,12 @@ func TestResourceValidate(t *testing.T) {
 		{NewResource("mybucket", "/myobject*"), "mybucket", false},
 		{NewResource("", "/myobject*"), "yourbucket", true},
 		{NewResource("mybucket", "/myobject*"), "yourbucket", true},
+		{NewResource("mybucket*a", "/myobject*"), "mybucket-east-a", false},
+
+		// Following test cases **should validate** successfully - they are
+		// corner cases for the given patterns and buckets.
+		{NewResource("mybucket*a", "/myobject*"), "mybucket", false},
+		{NewResource("mybucket*a", "/myobject*"), "mybucket22", false},
 	}
 
 	for i, testCase := range testCases {
@@ -216,7 +222,7 @@ func TestResourceValidate(t *testing.T) {
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {
-			t.Fatalf("case %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+			t.Errorf("case %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
 		}
 	}
 }

--- a/wildcard/match.go
+++ b/wildcard/match.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -66,4 +66,37 @@ func deepMatchRune(str, pattern []rune, simple bool) bool {
 		pattern = pattern[1:]
 	}
 	return len(str) == 0 && len(pattern) == 0
+}
+
+// MatchAsPatternPrefix matches text as a prefix of the given pattern. Examples:
+//
+//	| Pattern | Text    | Match Result |
+//	====================================
+//	| abc*    | ab      | True         |
+//	| abc*    | abd     | False        |
+//	| abc*c   | abcd    | True         |
+//	| ab*??d  | abxxc   | True         |
+//	| ab*??d  | abxc    | True         |
+//	| ab??d   | abxc    | True         |
+//	| ab??d   | abc     | True         |
+//	| ab??d   | abcxdd  | False        |
+//
+// This function is only useful in some special situations.
+func MatchAsPatternPrefix(pattern, text string) bool {
+	return matchAsPatternPrefix([]rune(pattern), []rune(text))
+}
+
+func matchAsPatternPrefix(pattern, text []rune) bool {
+	for i := 0; i < len(text) && i < len(pattern); i++ {
+		if pattern[i] == '*' {
+			return true
+		}
+		if pattern[i] == '?' {
+			continue
+		}
+		if pattern[i] != text[i] {
+			return false
+		}
+	}
+	return len(text) <= len(pattern)
 }

--- a/wildcard/match_test.go
+++ b/wildcard/match_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -15,12 +15,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package wildcard_test
+package wildcard
 
 import (
 	"testing"
-
-	"github.com/minio/pkg/wildcard"
 )
 
 // TestMatch - Tests validate the logic of wild card matching.
@@ -378,7 +376,7 @@ func TestMatch(t *testing.T) {
 	}
 	// Iterating over the test cases, call the function under test and assert the output.
 	for i, testCase := range testCases {
-		actualResult := wildcard.Match(testCase.pattern, testCase.text)
+		actualResult := Match(testCase.pattern, testCase.text)
 		if testCase.matched != actualResult {
 			t.Errorf("Test %d: Expected the result to be `%v`, but instead found it to be `%v`", i+1, testCase.matched, actualResult)
 		}
@@ -547,7 +545,102 @@ func TestMatchSimple(t *testing.T) {
 	}
 	// Iterating over the test cases, call the function under test and assert the output.
 	for i, testCase := range testCases {
-		actualResult := wildcard.MatchSimple(testCase.pattern, testCase.text)
+		actualResult := MatchSimple(testCase.pattern, testCase.text)
+		if testCase.matched != actualResult {
+			t.Errorf("Test %d: Expected the result to be `%v`, but instead found it to be `%v`", i+1, testCase.matched, actualResult)
+		}
+	}
+}
+
+func TestMatchAsPatternPrefix(t *testing.T) {
+	testCases := []struct {
+		pattern string
+		text    string
+		matched bool
+	}{
+		{
+			pattern: "",
+			text:    "",
+			matched: true,
+		},
+		{
+			pattern: "a",
+			text:    "",
+			matched: true,
+		},
+		{ // case 3
+			pattern: "a",
+			text:    "b",
+			matched: false,
+		},
+		{
+			pattern: "",
+			text:    "b",
+			matched: false,
+		},
+		{
+			pattern: "abc",
+			text:    "ab",
+			matched: true,
+		},
+		{ // case 6
+			pattern: "ab*",
+			text:    "ab",
+			matched: true,
+		},
+		{
+			pattern: "abc*",
+			text:    "ab",
+			matched: true,
+		},
+		{
+			pattern: "abc?",
+			text:    "ab",
+			matched: true,
+		},
+		{
+			pattern: "abc*",
+			text:    "abd",
+			matched: false,
+		},
+		{ // case 10
+			pattern: "abc*c",
+			text:    "abcd",
+			matched: true,
+		},
+		{
+			pattern: "ab*??d",
+			text:    "abxxc",
+			matched: true,
+		},
+		{
+			pattern: "ab*??",
+			text:    "abxc",
+			matched: true,
+		},
+		{
+			pattern: "ab??",
+			text:    "abxc",
+			matched: true,
+		},
+		{
+			pattern: "ab??",
+			text:    "abx",
+			matched: true,
+		},
+		{ // case 15
+			pattern: "ab??d",
+			text:    "abcxd",
+			matched: true,
+		},
+		{
+			pattern: "ab??d",
+			text:    "abcxdd",
+			matched: false,
+		},
+	}
+	for i, testCase := range testCases {
+		actualResult := MatchAsPatternPrefix(testCase.pattern, testCase.text)
 		if testCase.matched != actualResult {
 			t.Errorf("Test %d: Expected the result to be `%v`, but instead found it to be `%v`", i+1, testCase.matched, actualResult)
 		}


### PR DESCRIPTION
This fixes some corner cases in bucket matching in bucket policy
resources.

Failing tests for bucket/policy resource in existing implementation are
added.

This happens because we cannot parse out a unique bucket pattern from a
resource string in all cases: when resource pattern is
`mybucket*a/myobject*`, it should match `mybucket/a/myobject`.

For this pattern, the buckets matched are:
   1. `mybucket` (e.g. resource value is "mybucket/a/myobject"),
   2. `mybucketXa`, where X is a string not containing a `/` (e.g.
   resource value is "mybucket-east-a/myobject"), and
   3. `mybucketY`, where Y is a string not containing a `/` (e.g.
   resource value that matches is "mybucket22/a/myobject")

To fix this a new MatchAsPatternPrefix function added to wildcard
package and bucket name matching code is updated.