### PR TITLE
basic composable sftp server boilerplate

### DIFF
--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2022-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package sftp
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type (
+	// LogType defined various types of logs and errors
+	// that can happen within the SFTP implementation
+	LogType string
+)
+
+var (
+	// ErrMissingConnectionHandlerFunction ...
+	ErrMissingConnectionHandlerFunction = errors.New("new connection handler is not defined")
+	// ErrMissingSSHConfig ...
+	ErrMissingSSHConfig = errors.New("ssh Config is not defined")
+	// ErrMissingLoggerInterface ...
+	ErrMissingLoggerInterface = errors.New("logger interface is not defined")
+	// ErrInvalidPort ...
+	ErrInvalidPort = errors.New("port must not be 0 or bigger then 65535")
+)
+
+const (
+	// ServerStarted is logged when the SFTP server is first launched.
+	ServerStarted LogType = "server-started"
+	// ChannelNotSession is logged when the SFTP receives a request for a new channel which is NOT of type 'session'.
+	ChannelNotSession LogType = "channel-not-session"
+	// AcceptNetworkError is logged when there is an error accepting network connections within the listener.
+	AcceptNetworkError LogType = "accept-network-error"
+	// SSHKeyExchangeError is logged when there is an error performing a key exchange between the SFTP client and server.
+	SSHKeyExchangeError LogType = "ssh-key-exchange-error"
+	// AcceptChannelError is logged when there is an error while trying to accept the new request channel.
+	AcceptChannelError LogType = "accept-channel-error"
+)
+
+// Logger implements a basic logging interface
+// for the SFTP server.
+type Logger interface {
+	Info(tag LogType, msg string)
+	Error(tag LogType, err error)
+}
+
+// Server implements a composable SFTP Server.
+type Server struct {
+	port                 int
+	publicIP             string
+	sshConfig            ssh.ServerConfig
+	sshHandshakeDeadline time.Duration
+	logger               Logger
+	beforeHandle         func(conn net.Conn, err error) (acceptConn bool)
+	handleSFTPSession    func(channel ssh.Channel, sconn *ssh.ServerConn)
+	listener             net.Listener
+}
+
+// Options defines required configurations
+// used when calling NewServer().
+type Options struct {
+	Port      int
+	PublicIP  string
+	Logger    Logger
+	SSHConfig *ssh.ServerConfig
+	// SSHHandshakeDeadline controls the time.Duration which ssh session
+	// have to complete their handshake. This option is not a part of the
+	// ssh.ServerConfig so we had to implement it separately.
+	SSHHandshakeDeadline time.Duration
+	// BeforeHandle will be executed before `HandleSFTPSession` and before
+	// error checking happens during the socket listener.Accept().
+	//
+	// if acceptConn is true the connection will be accepted, if not
+	// the .Close() method is called and the connection dropped.
+	BeforeHandle func(conn net.Conn, err error) (acceptConn bool)
+	// HandleSFTPSession is executed when a new SFTP session is requested.
+	HandleSFTPSession func(channel ssh.Channel, sconn *ssh.ServerConn)
+}
+
+func defaultBeforeAccept(_ net.Conn, _ error) (accept bool) {
+	return true
+}
+
+// NewServer composes a new Server{} object from the options given.
+//
+// It is recommended to use (2*time.Minute) as the SSHHandshakeDeadline.
+// 2 minutes is the default deadline for OpenSSH servers/clients.
+func NewServer(options *Options) (sftpServer *Server, err error) {
+	if options.HandleSFTPSession == nil {
+		return nil, ErrMissingConnectionHandlerFunction
+	}
+	if options.SSHConfig == nil {
+		return nil, ErrMissingSSHConfig
+	}
+	if options.Logger == nil {
+		return nil, ErrMissingLoggerInterface
+	}
+	if options.Port < 1 || options.Port > 65535 {
+		return nil, ErrInvalidPort
+	}
+
+	listener, nErr := net.Listen(
+		"tcp",
+		net.JoinHostPort(options.PublicIP, strconv.Itoa(options.Port)),
+	)
+	if nErr != nil {
+		return nil, nErr
+	}
+
+	return &Server{
+		publicIP:             options.PublicIP,
+		port:                 options.Port,
+		sshConfig:            *options.SSHConfig,
+		sshHandshakeDeadline: options.SSHHandshakeDeadline,
+		beforeHandle:         options.BeforeHandle,
+		handleSFTPSession:    options.HandleSFTPSession,
+		logger:               options.Logger,
+		listener:             listener,
+	}, nil
+}
+
+// Listen starts the SFTP server
+func (s *Server) Listen() (err error) {
+	s.logger.Info(ServerStarted,
+		"SFTP Server listening on "+
+			net.JoinHostPort(s.publicIP, strconv.Itoa(s.port)),
+	)
+
+	for {
+		conn, err := s.listener.Accept()
+		if s.beforeHandle != nil && !s.beforeHandle(conn, err) {
+			if conn != nil {
+				conn.Close()
+			}
+			continue
+		}
+		if err != nil {
+			// Temporary() is deprecated but since it's been deployed to
+			// current production builds I do not want to simply switch it out.
+			// ISSUE: https://github.com/golang/go/issues/45729
+			// According to golang updates the Temporary() functionality was
+			// not changed but the method simply marked deprecated, hence
+			// it is alright to keep it implemented for consistency.
+			// UPDATE: https://go-review.googlesource.com/c/go/+/340261
+			ne, ok := err.(net.Error)
+			if ok && (ne.Timeout() || ne.Temporary()) {
+				s.logger.Error(
+					AcceptNetworkError,
+					fmt.Errorf("error accepting connections: %w", err),
+				)
+				continue
+			}
+			return err
+		}
+
+		go s.handleConnection(conn)
+	}
+}
+
+func (s *Server) handleConnection(conn net.Conn) {
+	// Before use, a handshake must be performed on the incoming net.Conn.
+	conn.SetDeadline(time.Now().Add(s.sshHandshakeDeadline))
+	sconn, chans, reqs, err := ssh.NewServerConn(conn, &s.sshConfig)
+	if err != nil {
+		s.logger.Error(SSHKeyExchangeError, err)
+		return
+	}
+
+	// Once we are done with SSH handshake, remove deadline.
+	conn.SetDeadline(time.Time{})
+
+	// The incoming Request channel must be serviced.
+	go ssh.DiscardRequests(reqs)
+
+	// Service the incoming Channel channel.
+	for newChannel := range chans {
+		// Channels have a type, depending on the application level
+		// protocol intended. In the case of an SFTP session, this is "subsystem"
+		// with a payload string of "<length=4>sftp"
+		if newChannel.ChannelType() != "session" {
+			s.logger.Info(
+				ChannelNotSession,
+				"Channel type is not a session",
+			)
+			continue
+		}
+
+		channel, requests, err := newChannel.Accept()
+		if err != nil {
+			s.logger.Error(
+				AcceptChannelError,
+				fmt.Errorf("unable to accept request from channel: %w", err),
+			)
+			continue
+		}
+
+		// Sessions have out-of-band requests such as "shell",
+		// "pty-req" and "env".  Here we handle only the
+		// "subsystem" request.
+		go func(in <-chan *ssh.Request) {
+			for req := range in {
+				ok := false
+				if req.Type == "subsystem" {
+					if len(req.Payload) > 4 && string(req.Payload[4:]) == "sftp" {
+						ok = true
+						go s.handleSFTPSession(channel, sconn)
+					}
+				}
+
+				if req.WantReply {
+					// We only reply to SSH packets that have `sftp` payload, all other
+					// packets are rejected
+					req.Reply(ok, nil)
+				}
+			}
+		}(requests)
+	}
+}

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -97,10 +97,6 @@ type Options struct {
 	HandleSFTPSession func(channel ssh.Channel, sconn *ssh.ServerConn)
 }
 
-func defaultBeforeAccept(_ net.Conn, _ error) (accept bool) {
-	return true
-}
-
 // NewServer composes a new Server{} object from the options given.
 //
 // It is recommended to use (2*time.Minute) as the SSHHandshakeDeadline.


### PR DESCRIPTION
This composable SFTP implementation was made in preparation for extracting the current SFTP implementation details out of [minio](github.com/minio/minio) so they can be used elsewhere.

I did not add any code that changes the basic functionality of the current SFTP boilerplate code within [minio](github.com/minio/minio). We can improve on that later if needed.

The implementation is in-line with the current FTP package we are using which makes the composition of the FTP and SFTP packages feel familiar.

# Notes
At first I was thinking about refactoring this into `github.com/minio/internal` but it felt strange to be imporint `github.com/minio` into the minwall which is where we would also be using this pkg. The second option was to create a new repository for this wrapper, but that also felt like it would be too much. So I ended up placing it here. 
If there is a better place for it then let me know!

# Usage
The SFTP pkg usage would look something like this
![image](https://github.com/minio/pkg/assets/20964930/45188109-d671-4369-9f85-826949776c3d)


# Logger
The Logger interface could be used like this
![image](https://github.com/minio/pkg/assets/20964930/81f47f82-c1eb-47aa-af67-00a903ca8d82)

