### PR TITLE
Introduce S3Action type for S3 actions

### DIFF
--- a/policy/action.go
+++ b/policy/action.go
@@ -76,6 +76,9 @@ func (action Action) Match(a Action) bool {
 }
 
 // IsValid - checks if action is valid or not.
+//
+// Deprecated: IsValid is deprecated, use Type() and specific action type's
+// IsValid instead.
 func (action Action) IsValid() bool {
 	switch action.Type() {
 	case S3ActionType:

--- a/policy/action.go
+++ b/policy/action.go
@@ -18,532 +18,75 @@
 package policy
 
 import (
-	"github.com/minio/pkg/v2/policy/condition"
+	"strings"
+
 	"github.com/minio/pkg/v2/wildcard"
 )
 
+// ActionType - type of action.
+type ActionType string
+
+// Typed string constants for ActionType.
+const (
+	S3ActionType    ActionType = "s3"
+	STSActionType   ActionType = "sts"
+	KMSActionType   ActionType = "kms"
+	AdminActionType ActionType = "admin"
+)
+
 // Action - policy action.
-// Refer https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html
-// for more information about available actions.
 type Action string
 
 const (
-	// AbortMultipartUploadAction - AbortMultipartUpload Rest API action.
-	AbortMultipartUploadAction Action = "s3:AbortMultipartUpload"
-
-	// CreateBucketAction - CreateBucket Rest API action.
-	CreateBucketAction = "s3:CreateBucket"
-
-	// DeleteBucketAction - DeleteBucket Rest API action.
-	DeleteBucketAction = "s3:DeleteBucket"
-
-	// ForceDeleteBucketAction - DeleteBucket Rest API action when x-minio-force-delete flag
-	// is specified.
-	ForceDeleteBucketAction = "s3:ForceDeleteBucket"
-
-	// DeleteBucketPolicyAction - DeleteBucketPolicy Rest API action.
-	DeleteBucketPolicyAction = "s3:DeleteBucketPolicy"
-
-	// DeleteObjectAction - DeleteObject Rest API action.
-	DeleteObjectAction = "s3:DeleteObject"
-
-	// GetBucketLocationAction - GetBucketLocation Rest API action.
-	GetBucketLocationAction = "s3:GetBucketLocation"
-
-	// GetBucketNotificationAction - GetBucketNotification Rest API action.
-	GetBucketNotificationAction = "s3:GetBucketNotification"
-
-	// GetBucketPolicyAction - GetBucketPolicy Rest API action.
-	GetBucketPolicyAction = "s3:GetBucketPolicy"
-
-	// GetObjectAction - GetObject Rest API action.
-	GetObjectAction = "s3:GetObject"
-
-	// GetObjectAttributesAction - GetObjectVersionAttributes Rest API action.
-	GetObjectAttributesAction = "s3:GetObjectAttributes"
-
-	// HeadBucketAction - HeadBucket Rest API action. This action is unused in minio.
-	HeadBucketAction = "s3:HeadBucket"
-
-	// ListAllMyBucketsAction - ListAllMyBuckets (List buckets) Rest API action.
-	ListAllMyBucketsAction = "s3:ListAllMyBuckets"
-
-	// ListBucketAction - ListBucket Rest API action.
-	ListBucketAction = "s3:ListBucket"
-
-	// GetBucketPolicyStatusAction - Retrieves the policy status for a bucket.
-	GetBucketPolicyStatusAction = "s3:GetBucketPolicyStatus"
-
-	// ListBucketVersionsAction - ListBucketVersions Rest API action.
-	ListBucketVersionsAction = "s3:ListBucketVersions"
-
-	// ListBucketMultipartUploadsAction - ListMultipartUploads Rest API action.
-	ListBucketMultipartUploadsAction = "s3:ListBucketMultipartUploads"
-
-	// ListenNotificationAction - ListenNotification Rest API action.
-	// This is MinIO extension.
-	ListenNotificationAction = "s3:ListenNotification"
-
-	// ListenBucketNotificationAction - ListenBucketNotification Rest API action.
-	// This is MinIO extension.
-	ListenBucketNotificationAction = "s3:ListenBucketNotification"
-
-	// ListMultipartUploadPartsAction - ListParts Rest API action.
-	ListMultipartUploadPartsAction = "s3:ListMultipartUploadParts"
-
-	// PutBucketLifecycleAction - PutBucketLifecycle Rest API action.
-	PutBucketLifecycleAction = "s3:PutLifecycleConfiguration"
-
-	// GetBucketLifecycleAction - GetBucketLifecycle Rest API action.
-	GetBucketLifecycleAction = "s3:GetLifecycleConfiguration"
-
-	// PutBucketNotificationAction - PutObjectNotification Rest API action.
-	PutBucketNotificationAction = "s3:PutBucketNotification"
-
-	// PutBucketPolicyAction - PutBucketPolicy Rest API action.
-	PutBucketPolicyAction = "s3:PutBucketPolicy"
-
-	// PutObjectAction - PutObject Rest API action.
-	PutObjectAction = "s3:PutObject"
-
-	// DeleteObjectVersionAction - DeleteObjectVersion Rest API action.
-	DeleteObjectVersionAction = "s3:DeleteObjectVersion"
-
-	// DeleteObjectVersionTaggingAction - DeleteObjectVersionTagging Rest API action.
-	DeleteObjectVersionTaggingAction = "s3:DeleteObjectVersionTagging"
-
-	// GetObjectVersionAction - GetObjectVersionAction Rest API action.
-	GetObjectVersionAction = "s3:GetObjectVersion"
-
-	// GetObjectVersionAttributesAction - GetObjectVersionAttributes Rest API action.
-	GetObjectVersionAttributesAction = "s3:GetObjectVersionAttributes"
-
-	// GetObjectVersionTaggingAction - GetObjectVersionTagging Rest API action.
-	GetObjectVersionTaggingAction = "s3:GetObjectVersionTagging"
-
-	// PutObjectVersionTaggingAction - PutObjectVersionTagging Rest API action.
-	PutObjectVersionTaggingAction = "s3:PutObjectVersionTagging"
-
-	// BypassGovernanceRetentionAction - bypass governance retention for PutObjectRetention, PutObject and DeleteObject Rest API action.
-	BypassGovernanceRetentionAction = "s3:BypassGovernanceRetention"
-
-	// PutObjectRetentionAction - PutObjectRetention Rest API action.
-	PutObjectRetentionAction = "s3:PutObjectRetention"
-
-	// GetObjectRetentionAction - GetObjectRetention, GetObject, HeadObject Rest API action.
-	GetObjectRetentionAction = "s3:GetObjectRetention"
-
-	// GetObjectLegalHoldAction - GetObjectLegalHold, GetObject Rest API action.
-	GetObjectLegalHoldAction = "s3:GetObjectLegalHold"
-
-	// PutObjectLegalHoldAction - PutObjectLegalHold, PutObject Rest API action.
-	PutObjectLegalHoldAction = "s3:PutObjectLegalHold"
-
-	// GetBucketObjectLockConfigurationAction - GetBucketObjectLockConfiguration Rest API action
-	GetBucketObjectLockConfigurationAction = "s3:GetBucketObjectLockConfiguration"
-
-	// PutBucketObjectLockConfigurationAction - PutBucketObjectLockConfiguration Rest API action
-	PutBucketObjectLockConfigurationAction = "s3:PutBucketObjectLockConfiguration"
-
-	// GetBucketTaggingAction - GetBucketTagging Rest API action
-	GetBucketTaggingAction = "s3:GetBucketTagging"
-
-	// PutBucketTaggingAction - PutBucketTagging Rest API action
-	PutBucketTaggingAction = "s3:PutBucketTagging"
-
-	// GetObjectTaggingAction - Get Object Tags API action
-	GetObjectTaggingAction = "s3:GetObjectTagging"
-
-	// PutObjectTaggingAction - Put Object Tags API action
-	PutObjectTaggingAction = "s3:PutObjectTagging"
-
-	// DeleteObjectTaggingAction - Delete Object Tags API action
-	DeleteObjectTaggingAction = "s3:DeleteObjectTagging"
-
-	// PutBucketEncryptionAction - PutBucketEncryption REST API action
-	PutBucketEncryptionAction = "s3:PutEncryptionConfiguration"
-
-	// GetBucketEncryptionAction - GetBucketEncryption REST API action
-	GetBucketEncryptionAction = "s3:GetEncryptionConfiguration"
-
-	// PutBucketVersioningAction - PutBucketVersioning REST API action
-	PutBucketVersioningAction = "s3:PutBucketVersioning"
-
-	// GetBucketVersioningAction - GetBucketVersioning REST API action
-	GetBucketVersioningAction = "s3:GetBucketVersioning"
-	// GetReplicationConfigurationAction  - GetReplicationConfiguration REST API action
-	GetReplicationConfigurationAction = "s3:GetReplicationConfiguration"
-	// PutReplicationConfigurationAction  - PutReplicationConfiguration REST API action
-	PutReplicationConfigurationAction = "s3:PutReplicationConfiguration"
-
-	// ReplicateObjectAction  - ReplicateObject REST API action
-	ReplicateObjectAction = "s3:ReplicateObject"
-
-	// ReplicateDeleteAction  - ReplicateDelete REST API action
-	ReplicateDeleteAction = "s3:ReplicateDelete"
-
-	// ReplicateTagsAction  - ReplicateTags REST API action
-	ReplicateTagsAction = "s3:ReplicateTags"
-
-	// GetObjectVersionForReplicationAction  - GetObjectVersionForReplication REST API action
-	GetObjectVersionForReplicationAction = "s3:GetObjectVersionForReplication"
-
-	// RestoreObjectAction - RestoreObject REST API action
-	RestoreObjectAction = "s3:RestoreObject"
-	// ResetBucketReplicationStateAction - MinIO extension API ResetBucketReplicationState to reset replication state
-	// on a bucket
-	ResetBucketReplicationStateAction = "s3:ResetBucketReplicationState"
-
-	// PutObjectFanOutAction - PutObject like API action but allows PostUpload() fan-out.
-	PutObjectFanOutAction = "s3:PutObjectFanOut"
-
-	// AllActions - all API actions
-	AllActions = "s3:*"
+	s3ActionTypePrefix    = "s3:"
+	stsActionTypePrefix   = "sts:"
+	kmsActionTypePrefix   = "kms:"
+	adminActionTypePrefix = "admin:"
 )
 
-// List of all supported actions.
-var supportedActions = map[Action]struct{}{
-	AbortMultipartUploadAction:             {},
-	CreateBucketAction:                     {},
-	DeleteBucketAction:                     {},
-	ForceDeleteBucketAction:                {},
-	DeleteBucketPolicyAction:               {},
-	DeleteObjectAction:                     {},
-	GetBucketLocationAction:                {},
-	GetBucketNotificationAction:            {},
-	GetBucketPolicyAction:                  {},
-	GetObjectAction:                        {},
-	HeadBucketAction:                       {},
-	ListAllMyBucketsAction:                 {},
-	ListBucketAction:                       {},
-	GetBucketPolicyStatusAction:            {},
-	ListBucketVersionsAction:               {},
-	ListBucketMultipartUploadsAction:       {},
-	ListenNotificationAction:               {},
-	ListenBucketNotificationAction:         {},
-	ListMultipartUploadPartsAction:         {},
-	PutBucketLifecycleAction:               {},
-	GetBucketLifecycleAction:               {},
-	PutBucketNotificationAction:            {},
-	PutBucketPolicyAction:                  {},
-	PutObjectAction:                        {},
-	BypassGovernanceRetentionAction:        {},
-	PutObjectRetentionAction:               {},
-	GetObjectRetentionAction:               {},
-	GetObjectLegalHoldAction:               {},
-	PutObjectLegalHoldAction:               {},
-	GetBucketObjectLockConfigurationAction: {},
-	PutBucketObjectLockConfigurationAction: {},
-	GetBucketTaggingAction:                 {},
-	PutBucketTaggingAction:                 {},
-	GetObjectVersionAction:                 {},
-	GetObjectAttributesAction:              {},
-	GetObjectVersionAttributesAction:       {},
-	GetObjectVersionTaggingAction:          {},
-	DeleteObjectVersionAction:              {},
-	DeleteObjectVersionTaggingAction:       {},
-	PutObjectVersionTaggingAction:          {},
-	GetObjectTaggingAction:                 {},
-	PutObjectTaggingAction:                 {},
-	DeleteObjectTaggingAction:              {},
-	PutBucketEncryptionAction:              {},
-	GetBucketEncryptionAction:              {},
-	PutBucketVersioningAction:              {},
-	GetBucketVersioningAction:              {},
-	GetReplicationConfigurationAction:      {},
-	PutReplicationConfigurationAction:      {},
-	ReplicateObjectAction:                  {},
-	ReplicateDeleteAction:                  {},
-	ReplicateTagsAction:                    {},
-	GetObjectVersionForReplicationAction:   {},
-	RestoreObjectAction:                    {},
-	ResetBucketReplicationStateAction:      {},
-	PutObjectFanOutAction:                  {},
-	AllActions:                             {},
-}
-
-// List of all supported object actions.
-var supportedObjectActions = map[Action]struct{}{
-	AllActions:                           {},
-	AbortMultipartUploadAction:           {},
-	DeleteObjectAction:                   {},
-	GetObjectAction:                      {},
-	ListMultipartUploadPartsAction:       {},
-	PutObjectAction:                      {},
-	BypassGovernanceRetentionAction:      {},
-	PutObjectRetentionAction:             {},
-	GetObjectRetentionAction:             {},
-	PutObjectLegalHoldAction:             {},
-	GetObjectLegalHoldAction:             {},
-	GetObjectTaggingAction:               {},
-	PutObjectTaggingAction:               {},
-	DeleteObjectTaggingAction:            {},
-	GetObjectVersionAction:               {},
-	GetObjectVersionTaggingAction:        {},
-	DeleteObjectVersionAction:            {},
-	DeleteObjectVersionTaggingAction:     {},
-	PutObjectVersionTaggingAction:        {},
-	ReplicateObjectAction:                {},
-	ReplicateDeleteAction:                {},
-	ReplicateTagsAction:                  {},
-	GetObjectVersionForReplicationAction: {},
-	RestoreObjectAction:                  {},
-	ResetBucketReplicationStateAction:    {},
-	PutObjectFanOutAction:                {},
-	GetObjectAttributesAction:            {},
-	GetObjectVersionAttributesAction:     {},
-}
-
-// IsObjectAction - returns whether action is object type or not.
-func (action Action) IsObjectAction() bool {
-	for supAction := range supportedObjectActions {
-		if action.Match(supAction) {
-			return true
-		}
+// Type - returns type of action. If the action does not have a valid prefix,
+// returns empty string.
+func (action Action) Type() ActionType {
+	s := string(action)
+	switch {
+	case strings.HasPrefix(s, s3ActionTypePrefix):
+		return S3ActionType
+	case strings.HasPrefix(s, stsActionTypePrefix):
+		return STSActionType
+	case strings.HasPrefix(s, kmsActionTypePrefix):
+		return KMSActionType
+	case strings.HasPrefix(s, adminActionTypePrefix):
+		return AdminActionType
+	default:
+		return ""
 	}
-	return false
 }
 
-// Match - matches action name with action patter.
+// IsObjectAction - returns whether action is for an object.
+func (action Action) IsObjectAction() bool {
+	if action.Type() != S3ActionType {
+		return false
+	}
+	return S3Action(action).IsObjectAction()
+}
+
+// Match - matches action name with action pattern.
 func (action Action) Match(a Action) bool {
 	return wildcard.Match(string(action), string(a))
 }
 
 // IsValid - checks if action is valid or not.
 func (action Action) IsValid() bool {
-	for supAction := range supportedActions {
-		if action.Match(supAction) {
-			return true
-		}
-	}
-	return false
-}
-
-// ActionConditionKeyMap is alias for the map type used here.
-type ActionConditionKeyMap map[Action]condition.KeySet
-
-// Lookup - looks up the action in the condition key map.
-func (a ActionConditionKeyMap) Lookup(action Action) condition.KeySet {
-	commonKeys := []condition.Key{}
-	for _, keyName := range condition.CommonKeys {
-		commonKeys = append(commonKeys, keyName.ToKey())
-	}
-
-	ckeysMerged := condition.NewKeySet(commonKeys...)
-	for act, ckey := range a {
-		if action.Match(act) {
-			ckeysMerged.Merge(ckey)
-		}
-	}
-	return ckeysMerged
-}
-
-// IAMActionConditionKeyMap - holds mapping of supported condition key for an action.
-var IAMActionConditionKeyMap = createActionConditionKeyMap()
-
-func createActionConditionKeyMap() ActionConditionKeyMap {
-	commonKeys := []condition.Key{}
-	for _, keyName := range condition.CommonKeys {
-		commonKeys = append(commonKeys, keyName.ToKey())
-	}
-
-	allSupportedKeys := []condition.Key{}
-	for _, keyName := range condition.AllSupportedKeys {
-		allSupportedKeys = append(allSupportedKeys, keyName.ToKey())
-	}
-
-	return ActionConditionKeyMap{
-		AllActions: condition.NewKeySet(allSupportedKeys...),
-
-		AbortMultipartUploadAction: condition.NewKeySet(commonKeys...),
-
-		CreateBucketAction: condition.NewKeySet(commonKeys...),
-
-		DeleteObjectAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-			}, commonKeys...)...),
-
-		GetBucketLocationAction: condition.NewKeySet(commonKeys...),
-
-		GetBucketPolicyStatusAction: condition.NewKeySet(commonKeys...),
-
-		GetObjectAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3XAmzServerSideEncryption.ToKey(),
-				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-
-		HeadBucketAction: condition.NewKeySet(commonKeys...),
-
-		GetObjectAttributesAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-
-		GetObjectVersionAttributesAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-
-		ListAllMyBucketsAction: condition.NewKeySet(commonKeys...),
-
-		ListBucketAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3Prefix.ToKey(),
-				condition.S3Delimiter.ToKey(),
-				condition.S3MaxKeys.ToKey(),
-			}, commonKeys...)...),
-
-		ListBucketVersionsAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3Prefix.ToKey(),
-				condition.S3Delimiter.ToKey(),
-				condition.S3MaxKeys.ToKey(),
-			}, commonKeys...)...),
-
-		ListBucketMultipartUploadsAction: condition.NewKeySet(commonKeys...),
-
-		ListenNotificationAction: condition.NewKeySet(commonKeys...),
-
-		ListenBucketNotificationAction: condition.NewKeySet(commonKeys...),
-
-		ListMultipartUploadPartsAction: condition.NewKeySet(commonKeys...),
-
-		PutObjectAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3XAmzCopySource.ToKey(),
-				condition.S3XAmzServerSideEncryption.ToKey(),
-				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
-				condition.S3XAmzMetadataDirective.ToKey(),
-				condition.S3XAmzStorageClass.ToKey(),
-				condition.S3VersionID.ToKey(),
-				condition.S3ObjectLockRetainUntilDate.ToKey(),
-				condition.S3ObjectLockMode.ToKey(),
-				condition.S3ObjectLockLegalHold.ToKey(),
-				condition.RequestObjectTagKeys.ToKey(),
-				condition.RequestObjectTag.ToKey(),
-			}, commonKeys...)...),
-
-		// https://docs.aws.amazon.com/AmazonS3/latest/dev/list_amazons3.html
-		// LockLegalHold is not supported with PutObjectRetentionAction
-		PutObjectRetentionAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3XAmzServerSideEncryption.ToKey(),
-				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
-				condition.S3ObjectLockRemainingRetentionDays.ToKey(),
-				condition.S3ObjectLockRetainUntilDate.ToKey(),
-				condition.S3ObjectLockMode.ToKey(),
-				condition.S3VersionID.ToKey(),
-			}, commonKeys...)...),
-
-		GetObjectRetentionAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3XAmzServerSideEncryption.ToKey(),
-				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
-				condition.S3VersionID.ToKey(),
-			}, commonKeys...)...),
-
-		PutObjectLegalHoldAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3XAmzServerSideEncryption.ToKey(),
-				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
-				condition.S3ObjectLockLegalHold.ToKey(),
-				condition.S3VersionID.ToKey(),
-			}, commonKeys...)...),
-		GetObjectLegalHoldAction: condition.NewKeySet(commonKeys...),
-
-		// https://docs.aws.amazon.com/AmazonS3/latest/dev/list_amazons3.html
-		BypassGovernanceRetentionAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.S3ObjectLockRemainingRetentionDays.ToKey(),
-				condition.S3ObjectLockRetainUntilDate.ToKey(),
-				condition.S3ObjectLockMode.ToKey(),
-				condition.S3ObjectLockLegalHold.ToKey(),
-				condition.RequestObjectTagKeys.ToKey(),
-				condition.RequestObjectTag.ToKey(),
-			}, commonKeys...)...),
-
-		GetBucketObjectLockConfigurationAction: condition.NewKeySet(commonKeys...),
-		PutBucketObjectLockConfigurationAction: condition.NewKeySet(commonKeys...),
-		GetBucketTaggingAction:                 condition.NewKeySet(commonKeys...),
-		PutBucketTaggingAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.RequestObjectTagKeys.ToKey(),
-				condition.RequestObjectTag.ToKey(),
-			}, commonKeys...)...),
-		PutObjectTaggingAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-				condition.RequestObjectTagKeys.ToKey(),
-				condition.RequestObjectTag.ToKey(),
-			}, commonKeys...)...),
-		GetObjectTaggingAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-		DeleteObjectTaggingAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-
-		PutObjectVersionTaggingAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-				condition.RequestObjectTagKeys.ToKey(),
-				condition.RequestObjectTag.ToKey(),
-			}, commonKeys...)...),
-		GetObjectVersionAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-		GetObjectVersionTaggingAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-		DeleteObjectVersionAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-			}, commonKeys...)...),
-		DeleteObjectVersionTaggingAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-		GetReplicationConfigurationAction: condition.NewKeySet(commonKeys...),
-		PutReplicationConfigurationAction: condition.NewKeySet(commonKeys...),
-		ReplicateObjectAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-		ReplicateDeleteAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-		ReplicateTagsAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-		GetObjectVersionForReplicationAction: condition.NewKeySet(
-			append([]condition.Key{
-				condition.S3VersionID.ToKey(),
-				condition.ExistingObjectTag.ToKey(),
-			}, commonKeys...)...),
-		RestoreObjectAction:               condition.NewKeySet(commonKeys...),
-		ResetBucketReplicationStateAction: condition.NewKeySet(commonKeys...),
-		PutObjectFanOutAction:             condition.NewKeySet(commonKeys...),
+	switch action.Type() {
+	case S3ActionType:
+		return S3Action(action).IsValid()
+	case STSActionType:
+		return STSAction(action).IsValid()
+	case KMSActionType:
+		return KMSAction(action).IsValid()
+	case AdminActionType:
+		return AdminAction(action).IsValid()
+	default:
+		return false
 	}
 }

--- a/policy/action_test.go
+++ b/policy/action_test.go
@@ -42,22 +42,3 @@ func TestActionIsObjectAction(t *testing.T) {
 		}
 	}
 }
-
-func TestActionIsValid(t *testing.T) {
-	testCases := []struct {
-		action         Action
-		expectedResult bool
-	}{
-		{PutObjectAction, true},
-		{AbortMultipartUploadAction, true},
-		{Action("foo"), false},
-	}
-
-	for i, testCase := range testCases {
-		result := testCase.action.IsValid()
-
-		if testCase.expectedResult != result {
-			t.Fatalf("case %v: expected: %v, got: %v", i+1, testCase.expectedResult, result)
-		}
-	}
-}

--- a/policy/actionset.go
+++ b/policy/actionset.go
@@ -129,6 +129,8 @@ func (actionSet ActionSet) ToSlice() []Action {
 }
 
 // ToS3Slice - returns slice of S3 actions from the action set.
+//
+// Deprecated: This function will be removed in a future release.
 func (actionSet ActionSet) ToS3Slice() []S3Action {
 	actions := []S3Action{}
 	for action := range actionSet {
@@ -139,6 +141,8 @@ func (actionSet ActionSet) ToS3Slice() []S3Action {
 }
 
 // ToAdminSlice - returns slice of admin actions from the action set.
+//
+// Deprecated: This function will be removed in a future release.
 func (actionSet ActionSet) ToAdminSlice() []AdminAction {
 	actions := []AdminAction{}
 	for action := range actionSet {
@@ -149,6 +153,8 @@ func (actionSet ActionSet) ToAdminSlice() []AdminAction {
 }
 
 // ToSTSSlice - returns slice of STS actions from the action set.
+//
+// Deprecated: This function will be removed in a future release.
 func (actionSet ActionSet) ToSTSSlice() []STSAction {
 	actions := []STSAction{}
 	for action := range actionSet {
@@ -159,6 +165,8 @@ func (actionSet ActionSet) ToSTSSlice() []STSAction {
 }
 
 // ToKMSSlice - returns slice of kms actions from the action set.
+//
+// Deprecated: This function will be removed in a future release.
 func (actionSet ActionSet) ToKMSSlice() (actions []KMSAction) {
 	for action := range actionSet {
 		actions = append(actions, KMSAction(action))
@@ -197,8 +205,8 @@ func (actionSet ActionSet) ValidateS3() error {
 
 // ValidateAdmin checks if all actions are valid Admin actions
 func (actionSet ActionSet) ValidateAdmin() error {
-	for _, action := range actionSet.ToAdminSlice() {
-		if !action.IsValid() {
+	for action := range actionSet {
+		if !AdminAction(action).IsValid() {
 			return Errorf("unsupported admin action '%v'", action)
 		}
 	}
@@ -207,8 +215,8 @@ func (actionSet ActionSet) ValidateAdmin() error {
 
 // ValidateSTS checks if all actions are valid STS actions
 func (actionSet ActionSet) ValidateSTS() error {
-	for _, action := range actionSet.ToSTSSlice() {
-		if !action.IsValid() {
+	for action := range actionSet {
+		if !STSAction(action).IsValid() {
 			return Errorf("unsupported STS action '%v'", action)
 		}
 	}
@@ -217,19 +225,9 @@ func (actionSet ActionSet) ValidateSTS() error {
 
 // ValidateKMS checks if all actions are valid KMS actions
 func (actionSet ActionSet) ValidateKMS() error {
-	for _, action := range actionSet.ToKMSSlice() {
-		if !action.IsValid() {
+	for action := range actionSet {
+		if !KMSAction(action).IsValid() {
 			return Errorf("unsupported KMS action '%v'", action)
-		}
-	}
-	return nil
-}
-
-// Validate checks if all actions are valid
-func (actionSet ActionSet) Validate() error {
-	for _, action := range actionSet.ToSlice() {
-		if !action.IsValid() {
-			return Errorf("unsupported action '%v'", action)
 		}
 	}
 	return nil

--- a/policy/actionset.go
+++ b/policy/actionset.go
@@ -128,6 +128,16 @@ func (actionSet ActionSet) ToSlice() []Action {
 	return actions
 }
 
+// ToS3Slice - returns slice of S3 actions from the action set.
+func (actionSet ActionSet) ToS3Slice() []S3Action {
+	actions := []S3Action{}
+	for action := range actionSet {
+		actions = append(actions, S3Action(action))
+	}
+
+	return actions
+}
+
 // ToAdminSlice - returns slice of admin actions from the action set.
 func (actionSet ActionSet) ToAdminSlice() []AdminAction {
 	actions := []AdminAction{}
@@ -172,6 +182,16 @@ func (actionSet *ActionSet) UnmarshalJSON(data []byte) error {
 		actionSet.Add(Action(s))
 	}
 
+	return nil
+}
+
+// ValidateS3 checks if all actions are valid S3 actions.
+func (actionSet ActionSet) ValidateS3() error {
+	for _, action := range actionSet.ToS3Slice() {
+		if !action.IsValid() {
+			return Errorf("unsupported S3 action '%v'", action)
+		}
+	}
 	return nil
 }
 

--- a/policy/actionset_test.go
+++ b/policy/actionset_test.go
@@ -152,7 +152,9 @@ func TestActionSetUnmarshalJSON(t *testing.T) {
 			t.Fatalf("case %v: error during unmarshal: expected: %v, got: %v\n", i+1, testCase.expectUnmarshalErr, expectErr)
 		}
 
-		err = result.Validate()
+		// Action set validation is specific to the type of action. This test
+		// only uses S3 actions.
+		err = result.ValidateS3()
 		expectErr = (err != nil)
 		if expectErr != testCase.expectValidateErr {
 			t.Fatalf("case %v: error during validation: expected: %v, got: %v\n", i+1, testCase.expectValidateErr, expectErr)

--- a/policy/bucket-policy-statement.go
+++ b/policy/bucket-policy-statement.go
@@ -65,8 +65,8 @@ func (statement BPStatement) IsAllowed(args BucketPolicyArgs) bool {
 	return statement.Effect.IsAllowed(check())
 }
 
-// isValid - checks whether statement is valid or not.
-func (statement BPStatement) isValid() error {
+// validate - checks whether statement is valid or returns an error.
+func (statement BPStatement) validate() error {
 	if !statement.Effect.IsValid() {
 		return Errorf("invalid Effect %v", statement.Effect)
 	}
@@ -106,7 +106,7 @@ func (statement BPStatement) isValid() error {
 
 // Validate - validates Statement is for given bucket or not.
 func (statement BPStatement) Validate(bucketName string) error {
-	if err := statement.isValid(); err != nil {
+	if err := statement.validate(); err != nil {
 		return err
 	}
 

--- a/policy/bucket-policy-statement_test.go
+++ b/policy/bucket-policy-statement_test.go
@@ -301,7 +301,7 @@ func TestBPStatementIsValid(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		err := testCase.statement.isValid()
+		err := testCase.statement.validate()
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {

--- a/policy/bucket-policy.go
+++ b/policy/bucket-policy.go
@@ -80,7 +80,7 @@ func (policy BucketPolicy) isValid() error {
 	}
 
 	for _, statement := range policy.Statements {
-		if err := statement.isValid(); err != nil {
+		if err := statement.validate(); err != nil {
 			return err
 		}
 	}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -129,7 +129,8 @@ func (iamp Policy) MatchResource(resource string) bool {
 // IsAllowedActions returns all supported actions for this policy.
 func (iamp Policy) IsAllowedActions(bucketName, objectName string, conditionValues map[string][]string) ActionSet {
 	actionSet := make(ActionSet)
-	for action := range supportedActions {
+	for action := range supportedS3Actions {
+		action := Action(action)
 		if iamp.IsAllowed(Args{
 			BucketName:      bucketName,
 			ObjectName:      objectName,
@@ -210,20 +211,6 @@ func (iamp Policy) IsEmpty() bool {
 	return len(iamp.Statements) == 0
 }
 
-// isValid - checks if Policy is valid or not.
-func (iamp Policy) isValid() error {
-	if iamp.Version != DefaultVersion && iamp.Version != "" {
-		return Errorf("invalid version '%v'", iamp.Version)
-	}
-
-	for _, statement := range iamp.Statements {
-		if err := statement.isValid(); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // MergePolicies merges all the given policies into a single policy dropping any
 // duplicate statements.
 func MergePolicies(inputs ...Policy) Policy {
@@ -285,9 +272,18 @@ func (iamp *Policy) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Validate - validates all statements are for given bucket or not.
+// Validate - checks if Policy is valid or not.
 func (iamp Policy) Validate() error {
-	return iamp.isValid()
+	if iamp.Version != DefaultVersion && iamp.Version != "" {
+		return Errorf("invalid version '%v'", iamp.Version)
+	}
+
+	for _, statement := range iamp.Statements {
+		if err := statement.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ParseConfig - parses data in given reader to Iamp.

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -497,7 +497,7 @@ func TestPolicyIsValid(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		err := testCase.policy.isValid()
+		err := testCase.policy.Validate()
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {

--- a/policy/s3-action.go
+++ b/policy/s3-action.go
@@ -1,0 +1,549 @@
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package policy
+
+import (
+	"github.com/minio/pkg/v2/policy/condition"
+)
+
+// S3Action - for representing an S3 Action.
+type S3Action string
+
+// Constants for S3 actions. Refer
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html for more
+// information about available S3 actions.
+const (
+	// AbortMultipartUploadAction - AbortMultipartUpload Rest API action.
+	AbortMultipartUploadAction = "s3:AbortMultipartUpload"
+
+	// CreateBucketAction - CreateBucket Rest API action.
+	CreateBucketAction = "s3:CreateBucket"
+
+	// DeleteBucketAction - DeleteBucket Rest API action.
+	DeleteBucketAction = "s3:DeleteBucket"
+
+	// ForceDeleteBucketAction - DeleteBucket Rest API action when x-minio-force-delete flag
+	// is specified.
+	ForceDeleteBucketAction = "s3:ForceDeleteBucket"
+
+	// DeleteBucketPolicyAction - DeleteBucketPolicy Rest API action.
+	DeleteBucketPolicyAction = "s3:DeleteBucketPolicy"
+
+	// DeleteObjectAction - DeleteObject Rest API action.
+	DeleteObjectAction = "s3:DeleteObject"
+
+	// GetBucketLocationAction - GetBucketLocation Rest API action.
+	GetBucketLocationAction = "s3:GetBucketLocation"
+
+	// GetBucketNotificationAction - GetBucketNotification Rest API action.
+	GetBucketNotificationAction = "s3:GetBucketNotification"
+
+	// GetBucketPolicyAction - GetBucketPolicy Rest API action.
+	GetBucketPolicyAction = "s3:GetBucketPolicy"
+
+	// GetObjectAction - GetObject Rest API action.
+	GetObjectAction = "s3:GetObject"
+
+	// GetObjectAttributesAction - GetObjectVersionAttributes Rest API action.
+	GetObjectAttributesAction = "s3:GetObjectAttributes"
+
+	// HeadBucketAction - HeadBucket Rest API action. This action is unused in minio.
+	HeadBucketAction = "s3:HeadBucket"
+
+	// ListAllMyBucketsAction - ListAllMyBuckets (List buckets) Rest API action.
+	ListAllMyBucketsAction = "s3:ListAllMyBuckets"
+
+	// ListBucketAction - ListBucket Rest API action.
+	ListBucketAction = "s3:ListBucket"
+
+	// GetBucketPolicyStatusAction - Retrieves the policy status for a bucket.
+	GetBucketPolicyStatusAction = "s3:GetBucketPolicyStatus"
+
+	// ListBucketVersionsAction - ListBucketVersions Rest API action.
+	ListBucketVersionsAction = "s3:ListBucketVersions"
+
+	// ListBucketMultipartUploadsAction - ListMultipartUploads Rest API action.
+	ListBucketMultipartUploadsAction = "s3:ListBucketMultipartUploads"
+
+	// ListenNotificationAction - ListenNotification Rest API action.
+	// This is MinIO extension.
+	ListenNotificationAction = "s3:ListenNotification"
+
+	// ListenBucketNotificationAction - ListenBucketNotification Rest API action.
+	// This is MinIO extension.
+	ListenBucketNotificationAction = "s3:ListenBucketNotification"
+
+	// ListMultipartUploadPartsAction - ListParts Rest API action.
+	ListMultipartUploadPartsAction = "s3:ListMultipartUploadParts"
+
+	// PutBucketLifecycleAction - PutBucketLifecycle Rest API action.
+	PutBucketLifecycleAction = "s3:PutLifecycleConfiguration"
+
+	// GetBucketLifecycleAction - GetBucketLifecycle Rest API action.
+	GetBucketLifecycleAction = "s3:GetLifecycleConfiguration"
+
+	// PutBucketNotificationAction - PutObjectNotification Rest API action.
+	PutBucketNotificationAction = "s3:PutBucketNotification"
+
+	// PutBucketPolicyAction - PutBucketPolicy Rest API action.
+	PutBucketPolicyAction = "s3:PutBucketPolicy"
+
+	// PutObjectAction - PutObject Rest API action.
+	PutObjectAction = "s3:PutObject"
+
+	// DeleteObjectVersionAction - DeleteObjectVersion Rest API action.
+	DeleteObjectVersionAction = "s3:DeleteObjectVersion"
+
+	// DeleteObjectVersionTaggingAction - DeleteObjectVersionTagging Rest API action.
+	DeleteObjectVersionTaggingAction = "s3:DeleteObjectVersionTagging"
+
+	// GetObjectVersionAction - GetObjectVersionAction Rest API action.
+	GetObjectVersionAction = "s3:GetObjectVersion"
+
+	// GetObjectVersionAttributesAction - GetObjectVersionAttributes Rest API action.
+	GetObjectVersionAttributesAction = "s3:GetObjectVersionAttributes"
+
+	// GetObjectVersionTaggingAction - GetObjectVersionTagging Rest API action.
+	GetObjectVersionTaggingAction = "s3:GetObjectVersionTagging"
+
+	// PutObjectVersionTaggingAction - PutObjectVersionTagging Rest API action.
+	PutObjectVersionTaggingAction = "s3:PutObjectVersionTagging"
+
+	// BypassGovernanceRetentionAction - bypass governance retention for PutObjectRetention, PutObject and DeleteObject Rest API action.
+	BypassGovernanceRetentionAction = "s3:BypassGovernanceRetention"
+
+	// PutObjectRetentionAction - PutObjectRetention Rest API action.
+	PutObjectRetentionAction = "s3:PutObjectRetention"
+
+	// GetObjectRetentionAction - GetObjectRetention, GetObject, HeadObject Rest API action.
+	GetObjectRetentionAction = "s3:GetObjectRetention"
+
+	// GetObjectLegalHoldAction - GetObjectLegalHold, GetObject Rest API action.
+	GetObjectLegalHoldAction = "s3:GetObjectLegalHold"
+
+	// PutObjectLegalHoldAction - PutObjectLegalHold, PutObject Rest API action.
+	PutObjectLegalHoldAction = "s3:PutObjectLegalHold"
+
+	// GetBucketObjectLockConfigurationAction - GetBucketObjectLockConfiguration Rest API action
+	GetBucketObjectLockConfigurationAction = "s3:GetBucketObjectLockConfiguration"
+
+	// PutBucketObjectLockConfigurationAction - PutBucketObjectLockConfiguration Rest API action
+	PutBucketObjectLockConfigurationAction = "s3:PutBucketObjectLockConfiguration"
+
+	// GetBucketTaggingAction - GetBucketTagging Rest API action
+	GetBucketTaggingAction = "s3:GetBucketTagging"
+
+	// PutBucketTaggingAction - PutBucketTagging Rest API action
+	PutBucketTaggingAction = "s3:PutBucketTagging"
+
+	// GetObjectTaggingAction - Get Object Tags API action
+	GetObjectTaggingAction = "s3:GetObjectTagging"
+
+	// PutObjectTaggingAction - Put Object Tags API action
+	PutObjectTaggingAction = "s3:PutObjectTagging"
+
+	// DeleteObjectTaggingAction - Delete Object Tags API action
+	DeleteObjectTaggingAction = "s3:DeleteObjectTagging"
+
+	// PutBucketEncryptionAction - PutBucketEncryption REST API action
+	PutBucketEncryptionAction = "s3:PutEncryptionConfiguration"
+
+	// GetBucketEncryptionAction - GetBucketEncryption REST API action
+	GetBucketEncryptionAction = "s3:GetEncryptionConfiguration"
+
+	// PutBucketVersioningAction - PutBucketVersioning REST API action
+	PutBucketVersioningAction = "s3:PutBucketVersioning"
+
+	// GetBucketVersioningAction - GetBucketVersioning REST API action
+	GetBucketVersioningAction = "s3:GetBucketVersioning"
+	// GetReplicationConfigurationAction  - GetReplicationConfiguration REST API action
+	GetReplicationConfigurationAction = "s3:GetReplicationConfiguration"
+	// PutReplicationConfigurationAction  - PutReplicationConfiguration REST API action
+	PutReplicationConfigurationAction = "s3:PutReplicationConfiguration"
+
+	// ReplicateObjectAction  - ReplicateObject REST API action
+	ReplicateObjectAction = "s3:ReplicateObject"
+
+	// ReplicateDeleteAction  - ReplicateDelete REST API action
+	ReplicateDeleteAction = "s3:ReplicateDelete"
+
+	// ReplicateTagsAction  - ReplicateTags REST API action
+	ReplicateTagsAction = "s3:ReplicateTags"
+
+	// GetObjectVersionForReplicationAction  - GetObjectVersionForReplication REST API action
+	GetObjectVersionForReplicationAction = "s3:GetObjectVersionForReplication"
+
+	// RestoreObjectAction - RestoreObject REST API action
+	RestoreObjectAction = "s3:RestoreObject"
+	// ResetBucketReplicationStateAction - MinIO extension API ResetBucketReplicationState to reset replication state
+	// on a bucket
+	ResetBucketReplicationStateAction = "s3:ResetBucketReplicationState"
+
+	// PutObjectFanOutAction - PutObject like API action but allows PostUpload() fan-out.
+	PutObjectFanOutAction = "s3:PutObjectFanOut"
+
+	// AllActions - all API actions
+	AllActions = "s3:*"
+)
+
+// List of all supported S3 actions.
+var supportedS3Actions = map[S3Action]struct{}{
+	AbortMultipartUploadAction:             {},
+	CreateBucketAction:                     {},
+	DeleteBucketAction:                     {},
+	ForceDeleteBucketAction:                {},
+	DeleteBucketPolicyAction:               {},
+	DeleteObjectAction:                     {},
+	GetBucketLocationAction:                {},
+	GetBucketNotificationAction:            {},
+	GetBucketPolicyAction:                  {},
+	GetObjectAction:                        {},
+	HeadBucketAction:                       {},
+	ListAllMyBucketsAction:                 {},
+	ListBucketAction:                       {},
+	GetBucketPolicyStatusAction:            {},
+	ListBucketVersionsAction:               {},
+	ListBucketMultipartUploadsAction:       {},
+	ListenNotificationAction:               {},
+	ListenBucketNotificationAction:         {},
+	ListMultipartUploadPartsAction:         {},
+	PutBucketLifecycleAction:               {},
+	GetBucketLifecycleAction:               {},
+	PutBucketNotificationAction:            {},
+	PutBucketPolicyAction:                  {},
+	PutObjectAction:                        {},
+	BypassGovernanceRetentionAction:        {},
+	PutObjectRetentionAction:               {},
+	GetObjectRetentionAction:               {},
+	GetObjectLegalHoldAction:               {},
+	PutObjectLegalHoldAction:               {},
+	GetBucketObjectLockConfigurationAction: {},
+	PutBucketObjectLockConfigurationAction: {},
+	GetBucketTaggingAction:                 {},
+	PutBucketTaggingAction:                 {},
+	GetObjectVersionAction:                 {},
+	GetObjectAttributesAction:              {},
+	GetObjectVersionAttributesAction:       {},
+	GetObjectVersionTaggingAction:          {},
+	DeleteObjectVersionAction:              {},
+	DeleteObjectVersionTaggingAction:       {},
+	PutObjectVersionTaggingAction:          {},
+	GetObjectTaggingAction:                 {},
+	PutObjectTaggingAction:                 {},
+	DeleteObjectTaggingAction:              {},
+	PutBucketEncryptionAction:              {},
+	GetBucketEncryptionAction:              {},
+	PutBucketVersioningAction:              {},
+	GetBucketVersioningAction:              {},
+	GetReplicationConfigurationAction:      {},
+	PutReplicationConfigurationAction:      {},
+	ReplicateObjectAction:                  {},
+	ReplicateDeleteAction:                  {},
+	ReplicateTagsAction:                    {},
+	GetObjectVersionForReplicationAction:   {},
+	RestoreObjectAction:                    {},
+	ResetBucketReplicationStateAction:      {},
+	PutObjectFanOutAction:                  {},
+	AllActions:                             {},
+}
+
+// List of all supported S3 object actions.
+var supportedS3ObjectActions = map[S3Action]struct{}{
+	AllActions:                           {},
+	AbortMultipartUploadAction:           {},
+	DeleteObjectAction:                   {},
+	GetObjectAction:                      {},
+	ListMultipartUploadPartsAction:       {},
+	PutObjectAction:                      {},
+	BypassGovernanceRetentionAction:      {},
+	PutObjectRetentionAction:             {},
+	GetObjectRetentionAction:             {},
+	PutObjectLegalHoldAction:             {},
+	GetObjectLegalHoldAction:             {},
+	GetObjectTaggingAction:               {},
+	PutObjectTaggingAction:               {},
+	DeleteObjectTaggingAction:            {},
+	GetObjectVersionAction:               {},
+	GetObjectVersionTaggingAction:        {},
+	DeleteObjectVersionAction:            {},
+	DeleteObjectVersionTaggingAction:     {},
+	PutObjectVersionTaggingAction:        {},
+	ReplicateObjectAction:                {},
+	ReplicateDeleteAction:                {},
+	ReplicateTagsAction:                  {},
+	GetObjectVersionForReplicationAction: {},
+	RestoreObjectAction:                  {},
+	ResetBucketReplicationStateAction:    {},
+	PutObjectFanOutAction:                {},
+	GetObjectAttributesAction:            {},
+	GetObjectVersionAttributesAction:     {},
+}
+
+// IsValid - checks if the action is valid.
+func (action S3Action) IsValid() bool {
+	if _, ok := supportedS3Actions[action]; ok {
+		return true
+	}
+	// Check we have a wildcard match.
+	for supAction := range supportedS3Actions {
+		if Action(action).Match(Action(supAction)) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsObjectAction - returns whether action is for an object.
+func (action S3Action) IsObjectAction() bool {
+	for supAction := range supportedS3ObjectActions {
+		if Action(action).Match(Action(supAction)) {
+			return true
+		}
+	}
+	return false
+
+}
+
+// ActionConditionKeyMap is alias for the map type used here.
+type ActionConditionKeyMap map[Action]condition.KeySet
+
+// Lookup - looks up the action in the condition key map.
+func (a ActionConditionKeyMap) Lookup(action Action) condition.KeySet {
+	commonKeys := []condition.Key{}
+	for _, keyName := range condition.CommonKeys {
+		commonKeys = append(commonKeys, keyName.ToKey())
+	}
+
+	ckeysMerged := condition.NewKeySet(commonKeys...)
+	for act, ckey := range a {
+		if action.Match(act) {
+			ckeysMerged.Merge(ckey)
+		}
+	}
+	return ckeysMerged
+}
+
+// IAMActionConditionKeyMap - holds mapping of supported condition key for an action.
+var IAMActionConditionKeyMap = createActionConditionKeyMap()
+
+func createActionConditionKeyMap() ActionConditionKeyMap {
+	commonKeys := []condition.Key{}
+	for _, keyName := range condition.CommonKeys {
+		commonKeys = append(commonKeys, keyName.ToKey())
+	}
+
+	allSupportedKeys := []condition.Key{}
+	for _, keyName := range condition.AllSupportedKeys {
+		allSupportedKeys = append(allSupportedKeys, keyName.ToKey())
+	}
+
+	return ActionConditionKeyMap{
+		AllActions: condition.NewKeySet(allSupportedKeys...),
+
+		AbortMultipartUploadAction: condition.NewKeySet(commonKeys...),
+
+		CreateBucketAction: condition.NewKeySet(commonKeys...),
+
+		DeleteObjectAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+			}, commonKeys...)...),
+
+		GetBucketLocationAction: condition.NewKeySet(commonKeys...),
+
+		GetBucketPolicyStatusAction: condition.NewKeySet(commonKeys...),
+
+		GetObjectAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3XAmzServerSideEncryption.ToKey(),
+				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+
+		HeadBucketAction: condition.NewKeySet(commonKeys...),
+
+		GetObjectAttributesAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+
+		GetObjectVersionAttributesAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+
+		ListAllMyBucketsAction: condition.NewKeySet(commonKeys...),
+
+		ListBucketAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3Prefix.ToKey(),
+				condition.S3Delimiter.ToKey(),
+				condition.S3MaxKeys.ToKey(),
+			}, commonKeys...)...),
+
+		ListBucketVersionsAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3Prefix.ToKey(),
+				condition.S3Delimiter.ToKey(),
+				condition.S3MaxKeys.ToKey(),
+			}, commonKeys...)...),
+
+		ListBucketMultipartUploadsAction: condition.NewKeySet(commonKeys...),
+
+		ListenNotificationAction: condition.NewKeySet(commonKeys...),
+
+		ListenBucketNotificationAction: condition.NewKeySet(commonKeys...),
+
+		ListMultipartUploadPartsAction: condition.NewKeySet(commonKeys...),
+
+		PutObjectAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3XAmzCopySource.ToKey(),
+				condition.S3XAmzServerSideEncryption.ToKey(),
+				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
+				condition.S3XAmzMetadataDirective.ToKey(),
+				condition.S3XAmzStorageClass.ToKey(),
+				condition.S3VersionID.ToKey(),
+				condition.S3ObjectLockRetainUntilDate.ToKey(),
+				condition.S3ObjectLockMode.ToKey(),
+				condition.S3ObjectLockLegalHold.ToKey(),
+				condition.RequestObjectTagKeys.ToKey(),
+				condition.RequestObjectTag.ToKey(),
+			}, commonKeys...)...),
+
+		// https://docs.aws.amazon.com/AmazonS3/latest/dev/list_amazons3.html
+		// LockLegalHold is not supported with PutObjectRetentionAction
+		PutObjectRetentionAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3XAmzServerSideEncryption.ToKey(),
+				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
+				condition.S3ObjectLockRemainingRetentionDays.ToKey(),
+				condition.S3ObjectLockRetainUntilDate.ToKey(),
+				condition.S3ObjectLockMode.ToKey(),
+				condition.S3VersionID.ToKey(),
+			}, commonKeys...)...),
+
+		GetObjectRetentionAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3XAmzServerSideEncryption.ToKey(),
+				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
+				condition.S3VersionID.ToKey(),
+			}, commonKeys...)...),
+
+		PutObjectLegalHoldAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3XAmzServerSideEncryption.ToKey(),
+				condition.S3XAmzServerSideEncryptionCustomerAlgorithm.ToKey(),
+				condition.S3ObjectLockLegalHold.ToKey(),
+				condition.S3VersionID.ToKey(),
+			}, commonKeys...)...),
+		GetObjectLegalHoldAction: condition.NewKeySet(commonKeys...),
+
+		// https://docs.aws.amazon.com/AmazonS3/latest/dev/list_amazons3.html
+		BypassGovernanceRetentionAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.S3ObjectLockRemainingRetentionDays.ToKey(),
+				condition.S3ObjectLockRetainUntilDate.ToKey(),
+				condition.S3ObjectLockMode.ToKey(),
+				condition.S3ObjectLockLegalHold.ToKey(),
+				condition.RequestObjectTagKeys.ToKey(),
+				condition.RequestObjectTag.ToKey(),
+			}, commonKeys...)...),
+
+		GetBucketObjectLockConfigurationAction: condition.NewKeySet(commonKeys...),
+		PutBucketObjectLockConfigurationAction: condition.NewKeySet(commonKeys...),
+		GetBucketTaggingAction:                 condition.NewKeySet(commonKeys...),
+		PutBucketTaggingAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.RequestObjectTagKeys.ToKey(),
+				condition.RequestObjectTag.ToKey(),
+			}, commonKeys...)...),
+		PutObjectTaggingAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+				condition.RequestObjectTagKeys.ToKey(),
+				condition.RequestObjectTag.ToKey(),
+			}, commonKeys...)...),
+		GetObjectTaggingAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+		DeleteObjectTaggingAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+
+		PutObjectVersionTaggingAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+				condition.RequestObjectTagKeys.ToKey(),
+				condition.RequestObjectTag.ToKey(),
+			}, commonKeys...)...),
+		GetObjectVersionAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+		GetObjectVersionTaggingAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+		DeleteObjectVersionAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+			}, commonKeys...)...),
+		DeleteObjectVersionTaggingAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+		GetReplicationConfigurationAction: condition.NewKeySet(commonKeys...),
+		PutReplicationConfigurationAction: condition.NewKeySet(commonKeys...),
+		ReplicateObjectAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+		ReplicateDeleteAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+		ReplicateTagsAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+		GetObjectVersionForReplicationAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+		RestoreObjectAction:               condition.NewKeySet(commonKeys...),
+		ResetBucketReplicationStateAction: condition.NewKeySet(commonKeys...),
+		PutObjectFanOutAction:             condition.NewKeySet(commonKeys...),
+	}
+}

--- a/policy/statement.go
+++ b/policy/statement.go
@@ -31,6 +31,11 @@ type Statement struct {
 	NotActions ActionSet           `json:"NotAction,omitempty"`
 	Resources  ResourceSet         `json:"Resource,omitempty"`
 	Conditions condition.Functions `json:"Condition,omitempty"`
+
+	// managed values
+
+	// This is set during validation, and used during evaluation of the policy.
+	actionType ActionType
 }
 
 // IsAllowed - checks given policy args is allowed to continue the Rest API.
@@ -52,42 +57,17 @@ func (statement Statement) IsAllowed(args Args) bool {
 			resource += "/"
 		}
 
-		// For admin statements, resource match can be ignored.
-		if !statement.Resources.Match(resource, args.ConditionValues) && !statement.isAdmin() && !statement.isKMS() && !statement.isSTS() {
-			return false
+		// For non S3 statements, resource is ignored.
+		if statement.actionType == S3ActionType {
+			if !statement.Resources.Match(resource, args.ConditionValues) {
+				return false
+			}
 		}
 
 		return statement.Conditions.Evaluate(args.ConditionValues)
 	}
 
 	return statement.Effect.IsAllowed(check())
-}
-
-func (statement Statement) isAdmin() bool {
-	for action := range statement.Actions {
-		if AdminAction(action).IsValid() {
-			return true
-		}
-	}
-	return false
-}
-
-func (statement Statement) isSTS() bool {
-	for action := range statement.Actions {
-		if STSAction(action).IsValid() {
-			return true
-		}
-	}
-	return false
-}
-
-func (statement Statement) isKMS() bool {
-	for action := range statement.Actions {
-		if KMSAction(action).IsValid() {
-			return true
-		}
-	}
-	return false
 }
 
 // Validate - checks whether statement is valid or not.
@@ -101,43 +81,82 @@ func (statement Statement) Validate() error {
 	}
 
 	if len(statement.Actions) > 0 && len(statement.NotActions) > 0 {
-		return Errorf("Only exactly one of Action or NotAction may be provided")
+		return Errorf("Action and NotAction are mutually exclusive")
 	}
 
-	if statement.isAdmin() {
-		if err := statement.Actions.ValidateAdmin(); err != nil {
-			return err
-		}
-		for action := range statement.Actions {
-			keys := statement.Conditions.Keys()
-			keyDiff := keys.Difference(adminActionConditionKeyMap[action])
-			if !keyDiff.IsEmpty() {
-				return Errorf("unsupported condition keys '%v' used for action '%v'", keyDiff, action)
+	// In this implementation, a statement may have actions of a single
+	// ActionType only. For example, a statement with both "s3:GetObject" and
+	// "admin:*" actions is invalid.
+
+	// Check ActionType of all actions in the statement.
+	var firstActionType ActionType
+	for _, actionBlock := range []ActionSet{statement.Actions, statement.NotActions} {
+		for action := range actionBlock {
+			actType := action.Type()
+			if actType == "" {
+				return Errorf("invalid action %v", action)
+			}
+
+			if firstActionType == "" {
+				firstActionType = actType
+			} else if firstActionType != actType {
+				return Errorf("Actions of different types found in the statement")
 			}
 		}
-		return nil
 	}
 
-	if statement.isSTS() {
-		if err := statement.Actions.ValidateSTS(); err != nil {
-			return err
+	// Set the action type for the statement. This will never be empty because
+	// either Action or NotAction has been specified.
+	statement.actionType = firstActionType
+
+	switch statement.actionType {
+	case S3ActionType:
+		return statement.validateS3()
+	case STSActionType:
+		return statement.validateSTS()
+	case KMSActionType:
+		return statement.validateKMS()
+	case AdminActionType:
+		return statement.validateAdmin()
+	default:
+		return Errorf("unsupported action type %v", statement.actionType)
+	}
+}
+
+func (statement Statement) validateAdmin() error {
+	if err := statement.Actions.ValidateAdmin(); err != nil {
+		return err
+	}
+	for action := range statement.Actions {
+		keys := statement.Conditions.Keys()
+		keyDiff := keys.Difference(adminActionConditionKeyMap[action])
+		if !keyDiff.IsEmpty() {
+			return Errorf("unsupported condition keys '%v' used for action '%v'", keyDiff, action)
 		}
-		for action := range statement.Actions {
-			keys := statement.Conditions.Keys()
-			keyDiff := keys.Difference(stsActionConditionKeyMap[action])
-			if !keyDiff.IsEmpty() {
-				return Errorf("unsupported condition keys '%v' used for action '%v'", keyDiff, action)
-			}
+	}
+	return nil
+}
+
+func (statement Statement) validateSTS() error {
+	if err := statement.Actions.ValidateSTS(); err != nil {
+		return err
+	}
+	for action := range statement.Actions {
+		keys := statement.Conditions.Keys()
+		keyDiff := keys.Difference(stsActionConditionKeyMap[action])
+		if !keyDiff.IsEmpty() {
+			return Errorf("unsupported condition keys '%v' used for action '%v'", keyDiff, action)
 		}
-		return nil
 	}
+	return nil
 
-	if statement.isKMS() {
-		return statement.Actions.ValidateKMS()
-	}
+}
 
-	// Handle statement with S3 actions.
+func (statement Statement) validateKMS() error {
+	return statement.Actions.ValidateKMS()
+}
 
+func (statement Statement) validateS3() error {
 	if !statement.SID.IsValid() {
 		return Errorf("invalid SID %v", statement.SID)
 	}

--- a/policy/statement_test.go
+++ b/policy/statement_test.go
@@ -295,7 +295,7 @@ func TestStatementIsValid(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		err := testCase.statement.isValid()
+		err := testCase.statement.Validate()
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {

--- a/workers/workers_test.go
+++ b/workers/workers_test.go
@@ -56,7 +56,7 @@ func TestWorkers(t *testing.T) {
 			jobs: 5,
 		},
 	}
-	testFn := func(n, jobs int, mustFail bool) {
+	testFn := func(t *testing.T, n, jobs int, mustFail bool) {
 		var mu sync.Mutex
 		var jobsDone int
 		// Create workers for n concurrent workers
@@ -88,7 +88,7 @@ func TestWorkers(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
-			testFn(test.n, test.jobs, test.mustFail)
+			testFn(t, test.n, test.jobs, test.mustFail)
 		})
 	}
 


### PR DESCRIPTION
- Add ActionType and improve validation.
- Remove useless {policy,statement}.isValid
- Rename BucketPolicy`.isValid` to `.validate`
- Fix one-off typed constant AbortMultipartUploadAction to be untyped.

Mainly code improvement. Add a validation for Action and NotAction given in same statement.