### PR TITLE
Take accepted plans as input to validateEnterpriseLicense

### DIFF
--- a/licverifier/verifier.go
+++ b/licverifier/verifier.go
@@ -49,6 +49,7 @@ type LicenseInfo struct {
 	IssuedAt        time.Time // Time of license issue
 	ExpiresAt       time.Time // Time of license expiry
 	APIKey          string    // Subnet account API Key
+	IsTrial         bool      // Is this a TRIAL license?
 }
 
 // license key JSON field names
@@ -61,6 +62,7 @@ const (
 	issuedAt     = "iat"
 	plan         = "plan"
 	apiKey       = "apiKey"
+	trial        = "trial"
 )
 
 // parse PEM encoded PKCS1 or PKCS8 public key
@@ -151,6 +153,10 @@ func toLicenseInfo(token jwt.Token) (LicenseInfo, error) {
 	// apiKey is optional as it's not present in older licenses
 	apiKey, _ := claims[apiKey].(string)
 
+	// isTrial is optional as it's not present in older licenses
+	// default value = false
+	isTrial, _ := claims[trial].(bool)
+
 	return LicenseInfo{
 		LicenseID:       licID,
 		Email:           token.Subject(),
@@ -162,6 +168,7 @@ func toLicenseInfo(token jwt.Token) (LicenseInfo, error) {
 		IssuedAt:        iAt,
 		ExpiresAt:       token.Expiration(),
 		APIKey:          apiKey,
+		IsTrial:         isTrial,
 	}, nil
 }
 

--- a/subnet/license.go
+++ b/subnet/license.go
@@ -191,7 +191,7 @@ func (lv *LicenseValidator) ValidateEnterpriseLicense(acceptedPlans []string) (*
 		return nil, fmt.Errorf("this tool/service is not available to %s customers", li.Plan)
 	}
 
-	if li.ExpiresAt.Before(time.Now()) && li.Plan == "TRIAL" {
+	if li.ExpiresAt.Before(time.Now()) && li.IsTrial {
 		return nil, fmt.Errorf("trial license has expired on %v", li.ExpiresAt)
 	}
 	return li, nil


### PR DESCRIPTION
There are going to be multiple variants of ENTERPRISE license. So add ability to pass a list of accepted plans to the validation function.

Also read the optional new field `trial` from the license and use it in the validation (trial licenses don't get grace period after expiry)