### PR TITLE
Fix handling of empty values in `env.LookupEnv` and `env.Get`

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -55,7 +55,15 @@ func SetEnvOn() {
 
 // IsSet returns if the given env key is set.
 func IsSet(key string) bool {
-	return Get(key, "") != ""
+	privateMutex.RLock()
+	ok := envOff
+	privateMutex.RUnlock()
+	if !ok {
+		_, ok, _, _, _ = LookupEnv(key)
+		return ok
+	}
+	// Env lookup is off
+	return false
 }
 
 // Get retrieves the value of the environment variable named
@@ -67,8 +75,8 @@ func Get(key, defaultValue string) string {
 	ok := envOff
 	privateMutex.RUnlock()
 	if !ok {
-		v, _, _, _ := LookupEnv(key)
-		if v != "" {
+		v, ok, _, _, _ := LookupEnv(key)
+		if ok {
 			return strings.TrimSpace(v)
 		}
 	}

--- a/env/web_env.go
+++ b/env/web_env.go
@@ -173,7 +173,7 @@ func Environ() []string {
 // Additionally if the input is env://username:password@remote:port/
 // to fetch ENV values for the env value from a remote server.
 // In this case, it also returns the credentials username and password
-func LookupEnv(key string) (string, string, string, error) {
+func LookupEnv(key string) (string, bool, string, string, error) {
 	v, ok := os.LookupEnv(key)
 	if ok && strings.HasPrefix(v, webEnvScheme) {
 		// If env value starts with `env*://`
@@ -184,16 +184,16 @@ func LookupEnv(key string) (string, string, string, error) {
 			env, eok := os.LookupEnv("_" + key)
 			if eok {
 				// fallback to cached value if-any.
-				return env, user, pwd, nil
+				return env, eok, user, pwd, nil
 			}
-			return env, user, pwd, err
+			return env, eok, user, pwd, err
 		}
 		// Set the ENV value to _env value,
 		// this value is a fallback in-case of
 		// server restarts when webhook server
 		// is down.
-		os.Setenv("_"+key, v)
-		return v, user, pwd, nil
+		_ = os.Setenv("_"+key, v)
+		return v, ok, user, pwd, nil
 	}
-	return v, "", "", nil
+	return v, ok, "", "", nil
 }


### PR DESCRIPTION
With the changes from https://github.com/minio/pkg/commit/716cd4d05b704a00ae42bdacc383134f7763e2f0, `env.LookupEnv` and `env.Get` have no longer been able to distinguish between environment variables that are not set and variables that are set, but have an empty string as the value. This contradicts the descriptions of both, which state that an empty value should still be respected and correctly handled. Additionally, `env.IsSet` also incorrectly considers set-but-empty environment variables as unset.

Importantly, this uncovered a bug in MinIO, where setting `MINIO_COMPRESSION_EXTENSIONS=` and `MINIO_COMPRESSION_MIME_TYPES=` causes the environment variables to be ignored, even though this is the intended way to [enable compression for all compressible objects](https://min.io/docs/minio/linux/administration/object-management/data-compression.html#compress-all-compressible-objects) when using [environment variables](https://min.io/docs/minio/linux/reference/minio-server/settings/core.html#id12), leading to the default compression extension and MIME type filters being applied. The fix for MinIO can be found in PR TODO.

This fix necessarily changes the semantics of `env.LookupEnv` slightly to expose the underlying existence check boolean (again), and needs minor changes on MinIO's side (in PR TODO), but at least https://github.com/minio/console and https://github.com/minio/mc do not need any changes in reponse.

For `env.IsSet`, I have also added a check that considers all environment variables as unset if environment lookup is disabled, which better matches the intention of the function. However, I can remove this check if looking up the set status should be possible even when lookups are disabled.