### PR TITLE
Improvements in enterprise license validator

### DIFF
--- a/subnet/license.go
+++ b/subnet/license.go
@@ -248,7 +248,11 @@ func (lv *LicenseValidator) ValidateEnterpriseLicense(acceptedPlans []string, li
 	// validation successful. start a background routine to validate the license
 	// - daily if already expired (within grace period)
 	// - just after expiry if not expired
-	go lv.scheduleNextLicenseCheck(li, acceptedPlans, licExpiredChan)
+	if licExpiredChan != nil {
+		// if the expiry channel is nil, it means client doesn't want to be notified
+		// when license expires. In that case we don't schedule the background check.
+		go lv.scheduleNextLicenseCheck(li, acceptedPlans, licExpiredChan)
+	}
 
 	return li, nil
 }


### PR DESCRIPTION
- Allow license validation without future expiry notification

There could be certain flows where the caller doesn't want to be notified when the license expires. In such cases, the caller can pass the expiry channel as nil, and in that case, the goroutine to schedule future license validations should not be spawned.

- Allow passing license token for validation

In some cases e.g. enterprise-console, caller may want to explicitly pass the license token for validation. Accept it in the param LicenseToken and when passed, do not try to read the token from env variable or minio.license file.