### PR TITLE
Update LDAP API to lookup addl. attributes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 # This ensures that previous jobs for the PR are canceled when the PR is
 # updated.
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
     steps:
-    - name: Set up Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-      id: go
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
 
-    - name: Test
-      run: make test
+      - name: Test
+        run: make test

--- a/.github/workflows/ldap.yaml
+++ b/.github/workflows/ldap.yaml
@@ -2,9 +2,9 @@ name: LDAP Config Validator
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 # This ensures that previous jobs for the PR are canceled when the PR is
 # updated.
@@ -31,14 +31,14 @@ jobs:
           LDAP_ADMIN_PASSWORD: "admin"
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -49,4 +49,4 @@ jobs:
       - name: Test with LDAP server
         env:
           LDAP_TEST_SERVER: "localhost:389"
-        run: make test
+        run: make test-ldap

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,16 @@ getdeps:
 
 lint: getdeps
 	@echo "Running $@ check"
-	@GO111MODULE=on ${GOPATH}/bin/golangci-lint cache clean
-	@GO111MODULE=on ${GOPATH}/bin/golangci-lint run --build-tags kqueue --timeout=10m --config ./.golangci.yml
+	@${GOPATH}/bin/golangci-lint cache clean
+	@${GOPATH}/bin/golangci-lint run --build-tags kqueue --timeout=10m --config ./.golangci.yml
 
 test: lint
 	@echo "Running unit tests"
-	@GO111MODULE=on go test -race -tags kqueue ./...
+	@go test -race -tags kqueue ./...
+
+test-ldap: lint
+	@echo "Running unit tests for LDAP with LDAP server at '"${LDAP_TEST_SERVER}"'"
+	@go test -v -race ./ldap
 
 clean:
 	@echo "Cleaning up all the generated files"

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/minio/pkg/v2/certs"
+	"github.com/minio/pkg/v3/certs"
 )
 
 func updateCerts(crt, key string) {

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/minio/pkg/v2/env"
+	"github.com/minio/pkg/v3/env"
 	"github.com/rjeczalik/notify"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/minio/pkg/v2
+module github.com/minio/pkg/v3
 
 go 1.21
 

--- a/ldap/validation_test.go
+++ b/ldap/validation_test.go
@@ -32,6 +32,7 @@ const (
 func TestConfigValidator(t *testing.T) {
 	ldapServer := os.Getenv(EnvTestLDAPServer)
 	if ldapServer == "" {
+		t.Logf("Skipping test as %s is not set", EnvTestLDAPServer)
 		t.Skip()
 	}
 	testCases := []struct {

--- a/policy/action.go
+++ b/policy/action.go
@@ -18,8 +18,8 @@
 package policy
 
 import (
-	"github.com/minio/pkg/v2/policy/condition"
-	"github.com/minio/pkg/v2/wildcard"
+	"github.com/minio/pkg/v3/policy/condition"
+	"github.com/minio/pkg/v3/wildcard"
 )
 
 // Action - policy action.

--- a/policy/admin-action.go
+++ b/policy/admin-action.go
@@ -18,7 +18,7 @@
 package policy
 
 import (
-	"github.com/minio/pkg/v2/policy/condition"
+	"github.com/minio/pkg/v3/policy/condition"
 )
 
 // AdminAction - admin policy action.

--- a/policy/bucket-policy-statement.go
+++ b/policy/bucket-policy-statement.go
@@ -20,7 +20,7 @@ package policy
 import (
 	"strings"
 
-	"github.com/minio/pkg/v2/policy/condition"
+	"github.com/minio/pkg/v3/policy/condition"
 )
 
 // BPStatement - policy statement.

--- a/policy/bucket-policy-statement_test.go
+++ b/policy/bucket-policy-statement_test.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/minio/pkg/v2/policy/condition"
+	"github.com/minio/pkg/v3/policy/condition"
 )
 
 func TestBPStatementIsAllowed(t *testing.T) {

--- a/policy/bucket-policy_test.go
+++ b/policy/bucket-policy_test.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/minio/pkg/v2/policy/condition"
+	"github.com/minio/pkg/v3/policy/condition"
 )
 
 func TestBucketPolicyIsAllowed(t *testing.T) {

--- a/policy/condition/stringfunc.go
+++ b/policy/condition/stringfunc.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	"github.com/minio/minio-go/v7/pkg/set"
-	"github.com/minio/pkg/v2/wildcard"
+	"github.com/minio/pkg/v3/wildcard"
 )
 
 func substitute(values map[string][]string) func(string) string {

--- a/policy/constants.go
+++ b/policy/constants.go
@@ -18,7 +18,7 @@
 package policy
 
 import (
-	"github.com/minio/pkg/v2/policy/condition"
+	"github.com/minio/pkg/v3/policy/condition"
 )
 
 // Policy claim constants

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/minio/minio-go/v7/pkg/set"
-	"github.com/minio/pkg/v2/policy/condition"
+	"github.com/minio/pkg/v3/policy/condition"
 )
 
 func TestGetPoliciesFromClaims(t *testing.T) {

--- a/policy/principal.go
+++ b/policy/principal.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 
 	"github.com/minio/minio-go/v7/pkg/set"
-	"github.com/minio/pkg/v2/wildcard"
+	"github.com/minio/pkg/v3/wildcard"
 )
 
 // Principal - policy principal.

--- a/policy/resource.go
+++ b/policy/resource.go
@@ -22,8 +22,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/minio/pkg/v2/policy/condition"
-	"github.com/minio/pkg/v2/wildcard"
+	"github.com/minio/pkg/v3/policy/condition"
+	"github.com/minio/pkg/v3/wildcard"
 )
 
 // ResourceARNPrefix - resource ARN prefix as per AWS S3 specification.

--- a/policy/statement.go
+++ b/policy/statement.go
@@ -20,7 +20,7 @@ package policy
 import (
 	"strings"
 
-	"github.com/minio/pkg/v2/policy/condition"
+	"github.com/minio/pkg/v3/policy/condition"
 )
 
 // Statement - iam policy statement.

--- a/policy/statement_test.go
+++ b/policy/statement_test.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/minio/pkg/v2/policy/condition"
+	"github.com/minio/pkg/v3/policy/condition"
 )
 
 func TestStatementIsAllowed(t *testing.T) {

--- a/policy/sts-action.go
+++ b/policy/sts-action.go
@@ -18,7 +18,7 @@
 package policy
 
 import (
-	"github.com/minio/pkg/v2/policy/condition"
+	"github.com/minio/pkg/v3/policy/condition"
 )
 
 // STSAction - STS policy action.

--- a/quick/quick.go
+++ b/quick/quick.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 
 	"github.com/fatih/structs"
-	"github.com/minio/pkg/v2/safe"
+	"github.com/minio/pkg/v3/safe"
 	etcd "go.etcd.io/etcd/client/v3"
 )
 

--- a/subnet/license.go
+++ b/subnet/license.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwt"
-	"github.com/minio/pkg/v2/licverifier"
+	"github.com/minio/pkg/v3/licverifier"
 )
 
 const (


### PR DESCRIPTION
- With this change, if additional LDAP attributes are specified in the
configuration, the server will fetch them when a user's DN is looked up
via `LookupUsername` (renamed here from `LookupDN`) and `LookupUserDN`.
The return types of these APIs are changed.

- Bump up to v3 as this causes API breakage.

- Update CI actions versions
