### PR TITLE
Keep license token read from file

### DIFF
--- a/subnet/license.go
+++ b/subnet/license.go
@@ -177,18 +177,15 @@ func (lv *LicenseValidator) ValidateLicense() (*licverifier.LicenseInfo, error) 
 		return nil, fmt.Errorf("MinIO license not found")
 	}
 
-	var lic string
-	if lv.LicenseToken != "" {
-		lic = lv.LicenseToken
-	} else {
+	if lv.LicenseToken == "" {
 		licData, err := os.ReadFile(lv.LicenseFilePath)
 		if err != nil {
 			return nil, err
 		}
-		lic = string(licData)
+		lv.LicenseToken = string(licData)
 	}
 
-	return lv.ParseLicense(lic)
+	return lv.ParseLicense(lv.LicenseToken)
 }
 
 func getDurationForNextLicenseCheck(li *licverifier.LicenseInfo) time.Duration {


### PR DESCRIPTION
Currently if the license token is read from the license file, the variable LicenseToken on the verifier remains empty, and caller cannot get the token value without reading the file again.

Keeping the read token in LicenseToken variable will help the caller to use it if required e.g. to automatically set the subnet license config if not present.