### PR TITLE
Trim license token

### DIFF
--- a/subnet/license.go
+++ b/subnet/license.go
@@ -182,7 +182,7 @@ func (lv *LicenseValidator) ValidateLicense() (*licverifier.LicenseInfo, error) 
 		if err != nil {
 			return nil, err
 		}
-		lv.LicenseToken = string(licData)
+		lv.LicenseToken = strings.TrimSpace(string(licData))
 	}
 
 	return lv.ParseLicense(lv.LicenseToken)


### PR DESCRIPTION
When license token is read from the license file, it can contain a newline at the end. If we try to set the same license in subnet config along with api_key, it fails with error:

`unknown sub-system  api_key`

as the api_key part moves to next line. Removing whitespace from the license token fixes this.