### PR TITLE
Use default certificate if no certificates match

### DIFF
--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -108,3 +108,33 @@ func TestValidPairAfterWrite(t *testing.T) {
 		t.Error("client certificate doesn't match expected certificate")
 	}
 }
+
+func TestNonMatchingCertificate(t *testing.T) {
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+	c, err := certs.NewManager(ctx, "public.crt", "private.key", tls.LoadX509KeyPair)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.AddCertificate("server.crt", "server.key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hello := &tls.ClientHelloInfo{ServerName: "non-matching"}
+	gcert, err := c.GetCertificate(hello)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCert, err := tls.LoadX509KeyPair("public.crt", "private.key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gcert.Certificate, expectedCert.Certificate) {
+		t.Error("certificate doesn't match expected certificate")
+	}
+	_, err = certs.NewManager(ctx, "public.crt", "new-private.key", tls.LoadX509KeyPair)
+	if err == nil {
+		t.Fatal("Expected to fail but got success")
+	}
+}

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -349,7 +349,15 @@ func (m *Manager) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, 
 			return certificate, nil
 		}
 	}
-	return nil, errors.New("certs: no server certificate is supported by peer")
+
+	// Check if there is a default certificate
+	certificate := m.certificates[m.defaultCert]
+	if certificate == nil {
+		return nil, errors.New("certs: no server certificate is supported by peer")
+	}
+
+	// Return the default certificate
+	return certificate, nil
 }
 
 // GetClientCertificate returns a TLS certificate for mTLS based on the
@@ -383,7 +391,15 @@ func (m *Manager) GetClientCertificate(reqInfo *tls.CertificateRequestInfo) (*tl
 			return certificate, nil
 		}
 	}
-	return nil, errors.New("certs: no client certificate is supported by peer")
+
+	// Check if there is a default defaultCert
+	defaultCert := m.certificates[m.defaultCert]
+	if defaultCert == nil {
+		return nil, errors.New("certs: no client certificate is supported by peer")
+	}
+
+	// Return the default certificate
+	return defaultCert, nil
 }
 
 // isSymlink returns true if the given file

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -391,15 +391,7 @@ func (m *Manager) GetClientCertificate(reqInfo *tls.CertificateRequestInfo) (*tl
 			return certificate, nil
 		}
 	}
-
-	// Check if there is a default defaultCert
-	defaultCert := m.certificates[m.defaultCert]
-	if defaultCert == nil {
-		return nil, errors.New("certs: no client certificate is supported by peer")
-	}
-
-	// Return the default certificate
-	return defaultCert, nil
+	return nil, errors.New("certs: no client certificate is supported by peer")
 }
 
 // isSymlink returns true if the given file


### PR DESCRIPTION
The default Go TLS implementation always returns the first certificate (that's the "default" or "fallback" certificate) if none of the certificates match ([source](https://cs.opensource.google/go/go/+/refs/tags/go1.22.5:src/crypto/tls/common.go;l=1162)). Although that may be an issue for the client, the TLS handshake can continue. If no certificate is returned at all, the TLS handshake is aborted and the client gets a TLS failure.

MinIO always returns the default certificate if there is only one certificate (source) or when no server-name is set. If multiple certificates are added and none of them matches then `nil` is returned. Although the function returns an error, this error isn't visible in the console and/or `mc admin trace`.

This PR changes the behavior, so it always returns the default certificate when none of the certificates match (just like the default Go TLS implementation). Although this may be considered less secure (it provides the server's FQDN when hitting the server with an arbitrary server name), this information is already provided when the attacker hits the server without SNI.