### PR TITLE
Fix deep recursion on star end

### DIFF
--- a/ellipses/ellipses_test.go
+++ b/ellipses/ellipses_test.go
@@ -238,7 +238,7 @@ func TestFindEllipsesPatterns(t *testing.T) {
 					return s
 				}
 				if !reflect.DeepEqual(got, testCase.want) {
-					t.Errorf(fmt.Sprintf("want %s,", repl(testCase.want)))
+					t.Errorf("want %s,", repl(testCase.want))
 					t.Errorf("got %s,", repl(got))
 				}
 			}

--- a/ellipses/list_test.go
+++ b/ellipses/list_test.go
@@ -173,7 +173,7 @@ func TestFindListPatterns(t *testing.T) {
 					return s
 				}
 				if !reflect.DeepEqual(got, testCase.want) {
-					t.Errorf(fmt.Sprintf("want %s,", repl(testCase.want)))
+					t.Errorf("want %s,", repl(testCase.want))
 					t.Errorf("got %s,", repl(got))
 				}
 			}

--- a/wildcard/match.go
+++ b/wildcard/match.go
@@ -29,7 +29,7 @@ func MatchSimple(pattern, name string) bool {
 		return true
 	}
 	// Do an extended wildcard '*' and '?' match.
-	return deepMatchRune([]rune(name), []rune(pattern), true)
+	return deepMatchRune(name, pattern, true)
 }
 
 // Match -  finds whether the text matches/satisfies the pattern string.
@@ -44,10 +44,10 @@ func Match(pattern, name string) (matched bool) {
 		return true
 	}
 	// Do an extended wildcard '*' and '?' match.
-	return deepMatchRune([]rune(name), []rune(pattern), false)
+	return deepMatchRune(name, pattern, false)
 }
 
-func deepMatchRune(str, pattern []rune, simple bool) bool {
+func deepMatchRune(str, pattern string, simple bool) bool {
 	for len(pattern) > 0 {
 		switch pattern[0] {
 		default:
@@ -59,8 +59,9 @@ func deepMatchRune(str, pattern []rune, simple bool) bool {
 				return simple
 			}
 		case '*':
-			return deepMatchRune(str, pattern[1:], simple) ||
-				(len(str) > 0 && deepMatchRune(str[1:], pattern, simple))
+			return len(pattern) == 1 || // Pattern ends with this star
+				deepMatchRune(str, pattern[1:], simple) || // Matches next part of pattern
+				(len(str) > 0 && deepMatchRune(str[1:], pattern, simple)) // Continue searching forward
 		}
 		str = str[1:]
 		pattern = pattern[1:]
@@ -83,10 +84,6 @@ func deepMatchRune(str, pattern []rune, simple bool) bool {
 //
 // This function is only useful in some special situations.
 func MatchAsPatternPrefix(pattern, text string) bool {
-	return matchAsPatternPrefix([]rune(pattern), []rune(text))
-}
-
-func matchAsPatternPrefix(pattern, text []rune) bool {
 	for i := 0; i < len(text) && i < len(pattern); i++ {
 		if pattern[i] == '*' {
 			return true


### PR DESCRIPTION
Also avoid very expensive string -> slice conversion

```
λ benchcmp before.txt after.txt
benchmark                                      old ns/op     new ns/op     delta
BenchmarkMatchSimple/0-prefix-reference-32     0.23          0.23          -0.55%
BenchmarkMatchSimple/bench-0-32                3771          3.83          -99.90%
BenchmarkMatchSimple/bench-1-32                0.93          0.72          -22.71%
BenchmarkMatchSimple/bench-2-32                0.70          0.59          -15.65%
BenchmarkMatchSimple/bench-3-32                1.63          1.41          -13.58%
BenchmarkMatchSimple/bench-4-32                201           6.24          -96.89%
BenchmarkMatchSimple/bench-5-32                77.6          18.2          -76.49%
BenchmarkMatchSimple/bench-6-32                57.6          17.9          -68.93%
BenchmarkMatchSimple/bench-7-32                115           37.1          -67.81%
BenchmarkMatchSimple/bench-8-32                58.6          17.0          -70.94%
BenchmarkMatchSimple/bench-9-32                163           17.6          -89.19%
BenchmarkMatchSimple/bench-10-32               70.8          14.9          -78.92%
BenchmarkMatchSimple/bench-11-32               154           87.8          -43.19%
BenchmarkMatchSimple/bench-12-32               366           197           -46.21%
BenchmarkMatchSimple/bench-13-32               361           199           -44.81%
BenchmarkMatchSimple/bench-14-32               498           294           -40.99%
BenchmarkMatchSimple/bench-15-32               394           251           -36.24%
BenchmarkMatchSimple/bench-16-32               260           86.4          -66.77%
BenchmarkMatchSimple/bench-17-32               96.8          15.4          -84.08%
BenchmarkMatchSimple/bench-18-32               57.2          16.2          -71.70%
BenchmarkMatchSimple/bench-19-32               82.8          19.2          -76.78%
BenchmarkMatchSimple/bench-20-32               59.8          16.6          -72.24%
BenchmarkMatchSimple/bench-21-32               69.3          6.95          -89.96%
BenchmarkMatchSimple/bench-22-32               15.4          3.82          -75.21%
```

Recursion could be fully avoided, but this should be good for now.