### PR TITLE
Add new action for getting license info

### DIFF
--- a/policy/admin-action.go
+++ b/policy/admin-action.go
@@ -59,6 +59,8 @@ const (
 	ServerInfoAdminAction = "admin:ServerInfo"
 	// HealthInfoAdminAction - allow obtaining cluster health information
 	HealthInfoAdminAction = "admin:OBDInfo"
+	// LicenseInfoAdminAction - allow obtaining license information
+	LicenseInfoAdminAction = "admin:LicenseInfo"
 	// BandwidthMonitorAction - allow monitoring bandwidth usage
 	BandwidthMonitorAction = "admin:BandwidthMonitor"
 	// InspectDataAction - allows downloading raw files from backend


### PR DESCRIPTION
This will be checked subsequently in minio for a new admin api 'license-info' that returns information about the license. That api will finally be used by clients to fetch and display the license details.