### PR TITLE
net: avoid TCPConfig nil pointer deref

### DIFF
--- a/net/tcp_linux.go
+++ b/net/tcp_linux.go
@@ -37,15 +37,15 @@ func (c *TCPConfig) control(_, address string, rc syscall.RawConn) error {
 		_ = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 
 		// Enable custom socket send/recv buffers.
-		if c.SendBufSize > 0 {
+		if c != nil && c.SendBufSize > 0 {
 			_ = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_SNDBUF, c.SendBufSize)
 		}
 
-		if c.RecvBufSize > 0 {
+		if c != nil && c.RecvBufSize > 0 {
 			_ = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_RCVBUF, c.RecvBufSize)
 		}
 
-		if c.NoDelay {
+		if c != nil && c.NoDelay {
 			_ = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, unix.TCP_NODELAY, 1)
 			_ = syscall.SetsockoptInt(fd, syscall.SOL_TCP, unix.TCP_CORK, 0)
 		}
@@ -86,11 +86,11 @@ func (c *TCPConfig) control(_, address string, rc syscall.RawConn) error {
 		//    https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/
 		// This is a sensitive configuration, it is better to set it to high values, > 60 secs since it can
 		// affect clients reading data with a very slow pace  (disappropriate with socket buffer sizes)
-		if c.UserTimeout > 0 {
+		if c != nil && c.UserTimeout > 0 {
 			_ = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, int(c.UserTimeout.Milliseconds()))
 		}
 
-		if c.Interface != "" {
+		if c != nil && c.Interface != "" {
 			if h, _, err := net.SplitHostPort(address); err == nil {
 				address = h
 			}


### PR DESCRIPTION
This commit prevents a panic if a `net.Dialer.Control` function is a pointer to the `TCPConfig.Control` method where `TCPConfig` is nil.

For example:
```
var conf *xnet.TCPConfig

dialer := net.Dialer{
  Control: conf.Control,
}
```