### PR TITLE
Add the SiteName field to the audit struct

### DIFF
--- a/logger/message/audit/entry.go
+++ b/logger/message/audit/entry.go
@@ -29,6 +29,7 @@ type ObjectVersion struct {
 type Entry struct {
 	Version      string    `json:"version"`
 	DeploymentID string    `json:"deploymentid,omitempty"`
+	SiteName     string    `json:"sitename,omitempty"`
 	Time         time.Time `json:"time"`
 	Event        string    `json:"event"`
 


### PR DESCRIPTION
 This is in preparation for the addition of the SiteName to both internal and external audit logs