### PR TITLE
Add NotResource policy statement element and fix NotResource for bucket policies

### DIFF
--- a/policy/bucket-policy-statement.go
+++ b/policy/bucket-policy-statement.go
@@ -56,11 +56,11 @@ func (statement BPStatement) IsAllowed(args BucketPolicyArgs) bool {
 			resource += args.ObjectName
 		}
 
-		if !statement.Resources.Match(resource, args.ConditionValues) {
+		if len(statement.Resources) > 0 && !statement.Resources.Match(resource, args.ConditionValues) {
 			return false
 		}
 
-		if statement.NotResources.Match(resource, args.ConditionValues) {
+		if len(statement.NotResources) > 0 && statement.NotResources.Match(resource, args.ConditionValues) {
 			return false
 		}
 
@@ -84,8 +84,16 @@ func (statement BPStatement) isValid() error {
 		return Errorf("Action must not be empty")
 	}
 
+	if len(statement.Actions) > 0 && len(statement.NotActions) > 0 {
+		return Errorf("Action and NotAction cannot be specified in the same statement")
+	}
+
 	if len(statement.Resources) == 0 && len(statement.NotResources) == 0 {
 		return Errorf("Resource must not be empty")
+	}
+
+	if len(statement.Resources) > 0 && len(statement.NotResources) > 0 {
+		return Errorf("Resource and NotResource cannot be specified in the same statement")
 	}
 
 	for action := range statement.Actions {

--- a/policy/bucket-policy-statement_test.go
+++ b/policy/bucket-policy-statement_test.go
@@ -107,6 +107,24 @@ func TestBPStatementIsAllowed(t *testing.T) {
 		condition.NewFunctions(),
 	)
 
+	case9Statement := NewBPStatementWithNotResource(
+		"",
+		Allow,
+		NewPrincipal("*"),
+		NewActionSet(GetObjectAction, PutObjectAction),
+		NewResourceSet(NewResource("mybucket/notmyobject*")),
+		condition.NewFunctions(),
+	)
+
+	case10Statement := NewBPStatementWithNotResource(
+		"",
+		Deny,
+		NewPrincipal("*"),
+		NewActionSet(GetObjectAction, PutObjectAction),
+		NewResourceSet(NewResource("mybucket/notmyobject*")),
+		condition.NewFunctions(),
+	)
+
 	anonGetBucketLocationArgs := BucketPolicyArgs{
 		AccountName:     "Q3AM3UQ867SPQQA43P2F",
 		Action:          GetBucketLocationAction,
@@ -222,6 +240,20 @@ func TestBPStatementIsAllowed(t *testing.T) {
 		{case8Statement, getBucketLocationArgs, false},
 		{case8Statement, putObjectActionArgs, false},
 		{case8Statement, getObjectActionArgs, false},
+
+		{case9Statement, anonGetBucketLocationArgs, false},
+		{case9Statement, anonPutObjectActionArgs, true},
+		{case9Statement, anonGetObjectActionArgs, true},
+		{case9Statement, getBucketLocationArgs, false},
+		{case9Statement, putObjectActionArgs, true},
+		{case9Statement, getObjectActionArgs, true},
+
+		{case10Statement, anonGetBucketLocationArgs, true},
+		{case10Statement, anonPutObjectActionArgs, false},
+		{case10Statement, anonGetObjectActionArgs, false},
+		{case10Statement, getBucketLocationArgs, true},
+		{case10Statement, putObjectActionArgs, false},
+		{case10Statement, getObjectActionArgs, false},
 	}
 
 	for i, testCase := range testCases {

--- a/policy/bucket-policy_test.go
+++ b/policy/bucket-policy_test.go
@@ -91,6 +91,26 @@ func TestBucketPolicyIsAllowed(t *testing.T) {
 		},
 	}
 
+	case5Policy := BucketPolicy{
+		Version: DefaultVersion,
+		Statements: []BPStatement{
+			NewBPStatement("",
+				Allow,
+				NewPrincipal("*"),
+				NewActionSet(GetObjectAction, PutObjectAction),
+				NewResourceSet(NewResource("mybucket/*")),
+				condition.NewFunctions(),
+			),
+			NewBPStatementWithNotResource("",
+				Deny,
+				NewPrincipal("*"),
+				NewActionSet(PutObjectAction),
+				NewResourceSet(NewResource("mybucket/notmyobject*")),
+				condition.NewFunctions(),
+			),
+		},
+	}
+
 	anonGetBucketLocationArgs := BucketPolicyArgs{
 		AccountName:     "Q3AM3UQ867SPQQA43P2F",
 		Action:          GetBucketLocationAction,
@@ -178,6 +198,13 @@ func TestBucketPolicyIsAllowed(t *testing.T) {
 		{case4Policy, getBucketLocationArgs, true},
 		{case4Policy, putObjectActionArgs, false},
 		{case4Policy, getObjectActionArgs, true},
+
+		{case5Policy, anonGetBucketLocationArgs, false},
+		{case5Policy, anonPutObjectActionArgs, false},
+		{case5Policy, anonGetObjectActionArgs, true},
+		{case5Policy, getBucketLocationArgs, false},
+		{case5Policy, putObjectActionArgs, false},
+		{case5Policy, getObjectActionArgs, true},
 	}
 
 	for i, testCase := range testCases {

--- a/policy/bucket-policy_test.go
+++ b/policy/bucket-policy_test.go
@@ -202,7 +202,7 @@ func TestBucketPolicyIsAllowed(t *testing.T) {
 		{case5Policy, anonGetBucketLocationArgs, false},
 		{case5Policy, anonPutObjectActionArgs, false},
 		{case5Policy, anonGetObjectActionArgs, true},
-		{case5Policy, getBucketLocationArgs, false},
+		{case5Policy, getBucketLocationArgs, true},
 		{case5Policy, putObjectActionArgs, false},
 		{case5Policy, getObjectActionArgs, true},
 	}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -188,6 +188,26 @@ func TestPolicyIsAllowed(t *testing.T) {
 		},
 	}
 
+	case5Policy := Policy{
+		Version: DefaultVersion,
+		Statements: []Statement{
+			NewStatement(
+				"",
+				Allow,
+				NewActionSet(GetObjectAction, PutObjectAction),
+				NewResourceSet(NewResource("mybucket/*")),
+				condition.NewFunctions(),
+			),
+			NewStatementWithNotResource(
+				"",
+				Deny,
+				NewActionSet(PutObjectAction),
+				NewResourceSet(NewResource("mybucket/notmyobject*")),
+				condition.NewFunctions(),
+			),
+		},
+	}
+
 	anonGetBucketLocationArgs := Args{
 		AccountName:     "Q3AM3UQ867SPQQA43P2F",
 		Action:          GetBucketLocationAction,
@@ -272,6 +292,13 @@ func TestPolicyIsAllowed(t *testing.T) {
 		{case4Policy, getBucketLocationArgs, false},
 		{case4Policy, putObjectActionArgs, false},
 		{case4Policy, getObjectActionArgs, false},
+
+		{case5Policy, anonGetBucketLocationArgs, false},
+		{case5Policy, anonPutObjectActionArgs, false},
+		{case5Policy, anonGetObjectActionArgs, true},
+		{case5Policy, getBucketLocationArgs, false},
+		{case5Policy, putObjectActionArgs, false},
+		{case5Policy, getObjectActionArgs, true},
 	}
 
 	for i, testCase := range testCases {

--- a/policy/statement.go
+++ b/policy/statement.go
@@ -27,12 +27,13 @@ import (
 
 // Statement - iam policy statement.
 type Statement struct {
-	SID        ID                  `json:"Sid,omitempty"`
-	Effect     Effect              `json:"Effect"`
-	Actions    ActionSet           `json:"Action"`
-	NotActions ActionSet           `json:"NotAction,omitempty"`
-	Resources  ResourceSet         `json:"Resource,omitempty"`
-	Conditions condition.Functions `json:"Condition,omitempty"`
+	SID          ID                  `json:"Sid,omitempty"`
+	Effect       Effect              `json:"Effect"`
+	Actions      ActionSet           `json:"Action"`
+	NotActions   ActionSet           `json:"NotAction,omitempty"`
+	Resources    ResourceSet         `json:"Resource,omitempty"`
+	NotResources ResourceSet         `json:"NotResource,omitempty"`
+	Conditions   condition.Functions `json:"Condition,omitempty"`
 }
 
 // smallBufPool should always return a non-nil *bytes.Buffer
@@ -75,7 +76,13 @@ func (statement Statement) IsAllowed(args Args) bool {
 		}
 
 		// For some admin statements, resource match can be ignored.
-		if !statement.Resources.Match(resource.String(), args.ConditionValues) && !statement.isAdmin() && !statement.isSTS() {
+		ignoreResourceMatch := statement.isAdmin() || statement.isSTS()
+
+		if !ignoreResourceMatch && len(statement.Resources) > 0 && !statement.Resources.Match(resource.String(), args.ConditionValues) {
+			return false
+		}
+
+		if !ignoreResourceMatch && len(statement.NotResources) > 0 && statement.NotResources.Match(resource.String(), args.ConditionValues) {
 			return false
 		}
 
@@ -122,6 +129,10 @@ func (statement Statement) isValid() error {
 		return Errorf("Action must not be empty")
 	}
 
+	if len(statement.Actions) > 0 && len(statement.NotActions) > 0 {
+		return Errorf("Action and NotAction cannot be specified in the same statement")
+	}
+
 	if statement.isAdmin() {
 		if err := statement.Actions.ValidateAdmin(); err != nil {
 			return err
@@ -154,18 +165,32 @@ func (statement Statement) isValid() error {
 		if err := statement.Actions.ValidateKMS(); err != nil {
 			return err
 		}
-		return statement.Resources.ValidateKMS()
+		if err := statement.Resources.ValidateKMS(); err != nil {
+			return err
+		}
+		if err := statement.NotResources.ValidateKMS(); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	if !statement.SID.IsValid() {
 		return Errorf("invalid SID %v", statement.SID)
 	}
 
-	if len(statement.Resources) == 0 {
+	if len(statement.Resources) == 0 && len(statement.NotResources) == 0 {
 		return Errorf("Resource must not be empty")
 	}
 
+	if len(statement.Resources) > 0 && len(statement.NotResources) > 0 {
+		return Errorf("Resource and NotResource cannot be specified in the same statement")
+	}
+
 	if err := statement.Resources.ValidateS3(); err != nil {
+		return err
+	}
+
+	if err := statement.NotResources.ValidateS3(); err != nil {
 		return err
 	}
 
@@ -174,8 +199,11 @@ func (statement Statement) isValid() error {
 	}
 
 	for action := range statement.Actions {
-		if !statement.Resources.ObjectResourceExists() && !statement.Resources.BucketResourceExists() {
+		if len(statement.Resources) > 0 && !statement.Resources.ObjectResourceExists() && !statement.Resources.BucketResourceExists() {
 			return Errorf("unsupported Resource found %v for action %v", statement.Resources, action)
+		}
+		if len(statement.NotResources) > 0 && !statement.NotResources.ObjectResourceExists() && !statement.NotResources.BucketResourceExists() {
+			return Errorf("unsupported NotResource found %v for action %v", statement.NotResources, action)
 		}
 
 		keys := statement.Conditions.Keys()
@@ -207,6 +235,9 @@ func (statement Statement) Equals(st Statement) bool {
 	if !statement.Resources.Equals(st.Resources) {
 		return false
 	}
+	if !statement.NotResources.Equals(st.NotResources) {
+		return false
+	}
 	if !statement.Conditions.Equals(st.Conditions) {
 		return false
 	}
@@ -216,12 +247,13 @@ func (statement Statement) Equals(st Statement) bool {
 // Clone clones Statement structure
 func (statement Statement) Clone() Statement {
 	return Statement{
-		SID:        statement.SID,
-		Effect:     statement.Effect,
-		Actions:    statement.Actions.Clone(),
-		NotActions: statement.NotActions.Clone(),
-		Resources:  statement.Resources.Clone(),
-		Conditions: statement.Conditions.Clone(),
+		SID:          statement.SID,
+		Effect:       statement.Effect,
+		Actions:      statement.Actions.Clone(),
+		NotActions:   statement.NotActions.Clone(),
+		Resources:    statement.Resources.Clone(),
+		NotResources: statement.NotResources.Clone(),
+		Conditions:   statement.Conditions.Clone(),
 	}
 }
 
@@ -233,6 +265,17 @@ func NewStatement(sid ID, effect Effect, actionSet ActionSet, resourceSet Resour
 		Actions:    actionSet,
 		Resources:  resourceSet,
 		Conditions: conditions,
+	}
+}
+
+// NewStatementWithNotResource - creates new statement with NotAction.
+func NewStatementWithNotResource(sid ID, effect Effect, actions ActionSet, notResources ResourceSet, conditions condition.Functions) Statement {
+	return Statement{
+		SID:          sid,
+		Effect:       effect,
+		Actions:      actions,
+		NotResources: notResources,
+		Conditions:   conditions,
 	}
 }
 

--- a/policy/statement_test.go
+++ b/policy/statement_test.go
@@ -67,48 +67,42 @@ func TestStatementIsAllowed(t *testing.T) {
 		condition.NewFunctions(func1),
 	)
 
-	case5Statement := NewStatementWithNotAction(
-		"",
+	case5Statement := NewStatementWithNotAction("",
 		Allow,
 		NewActionSet(GetObjectAction, CreateBucketAction),
 		NewResourceSet(NewResource("mybucket/myobject*"), NewResource("mybucket")),
 		condition.NewFunctions(),
 	)
 
-	case6Statement := NewStatementWithNotAction(
-		"",
+	case6Statement := NewStatementWithNotAction("",
 		Deny,
 		NewActionSet(GetObjectAction),
 		NewResourceSet(NewResource("mybucket/myobject*")),
 		condition.NewFunctions(func1),
 	)
 
-	case7Statement := NewStatementWithNotResource(
-		"",
+	case7Statement := NewStatementWithNotResource("",
 		Deny,
 		NewActionSet(GetObjectAction, PutObjectAction),
 		NewResourceSet(NewResource("mybucket/myobject*")),
 		condition.NewFunctions(),
 	)
 
-	case8Statement := NewStatementWithNotResource(
-		"",
+	case8Statement := NewStatementWithNotResource("",
 		Allow,
 		NewActionSet(GetObjectAction, PutObjectAction),
 		NewResourceSet(NewResource("mybucket/myobject*")),
 		condition.NewFunctions(),
 	)
 
-	case9Statement := NewStatementWithNotResource(
-		"",
+	case9Statement := NewStatementWithNotResource("",
 		Allow,
 		NewActionSet(GetObjectAction, PutObjectAction),
 		NewResourceSet(NewResource("mybucket/notmyobject*")),
 		condition.NewFunctions(),
 	)
 
-	case10Statement := NewStatementWithNotResource(
-		"",
+	case10Statement := NewStatementWithNotResource("",
 		Deny,
 		NewActionSet(GetObjectAction, PutObjectAction),
 		NewResourceSet(NewResource("mybucket/notmyobject*")),


### PR DESCRIPTION
Adds NotResource policy element as specified in S3 docs. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html

Same reason as #142, but that one only added NotResource for bucket policies. This adds NotResource for regular policies and fixes a problem with how NotResource was interpreted for bucket policies.

Also makes Action and NotAction mutually exclusive in a single statement to align with AWS documentation
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html

