### PR TITLE
Use golangci-lint v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,30 +1,40 @@
-linters-settings:
-  golint:
-    min-confidence: 0
-
-  misspell:
-    locale: US
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - typecheck
-    - goimports
-    - misspell
-    - govet
-    - revive
-    - ineffassign
-    - gosimple
     - gomodguard
-    - gofmt
-    - unused
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
     - unconvert
-
-issues:
-  exclude-use-default: false
-  exclude:
-      - should have a package comment
-      - error strings should not be capitalized or end with punctuation or a newline
-
-service:
-  golangci-lint-version: 1.20.0 # use the fixed version to not introduce new linters unexpectedly
+    - unused
+  settings:
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    rules:
+      - path: (.+)\.go$
+        text: "should have a package comment"
+      - path: (.+)\.go$
+        text: "ST1005"
+      - path: ldap/ldap.go$
+        text: "SA1019: ldap.Dial(TLS)?"
+      - path: sftp/sftp.go$
+        text: "SA1019: ne.Temporary"
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/certs/ca-certs.go
+++ b/certs/ca-certs.go
@@ -21,7 +21,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -67,7 +67,7 @@ func GetRootCAs(path string) (*x509.CertPool, error) {
 
 	// In case of a file add it to the root CAs.
 	if !stat.IsDir() {
-		bytes, err := ioutil.ReadAll(f)
+		bytes, err := io.ReadAll(f)
 		if err != nil {
 			return rootCAs, err
 		}
@@ -84,7 +84,7 @@ func GetRootCAs(path string) (*x509.CertPool, error) {
 		return rootCAs, err
 	}
 	for _, file := range files {
-		bytes, err := ioutil.ReadFile(filepath.Join(path, file))
+		bytes, err := os.ReadFile(filepath.Join(path, file))
 		if err == nil { // ignore files which are not readable.
 			rootCAs.AppendCertsFromPEM(bytes)
 		}

--- a/certs/ca-certs_test.go
+++ b/certs/ca-certs_test.go
@@ -18,20 +18,19 @@
 package certs
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestGetRootCAs(t *testing.T) {
-	emptydir, err := ioutil.TempDir("", "test-get-root-cas")
+	emptydir, err := os.MkdirTemp("", "test-get-root-cas")
 	if err != nil {
 		t.Fatalf("Unable create temp directory. %v", emptydir)
 	}
 	defer os.RemoveAll(emptydir)
 
-	dir1, err := ioutil.TempDir("", "test-get-root-cas")
+	dir1, err := os.MkdirTemp("", "test-get-root-cas")
 	if err != nil {
 		t.Fatalf("Unable create temp directory. %v", dir1)
 	}
@@ -40,12 +39,12 @@ func TestGetRootCAs(t *testing.T) {
 		t.Fatalf("Unable create empty dir. %v", err)
 	}
 
-	dir2, err := ioutil.TempDir("", "test-get-root-cas")
+	dir2, err := os.MkdirTemp("", "test-get-root-cas")
 	if err != nil {
 		t.Fatalf("Unable create temp directory. %v", dir2)
 	}
 	defer os.RemoveAll(dir2)
-	if err = ioutil.WriteFile(filepath.Join(dir2, "empty-file"), []byte{}, 0o644); err != nil {
+	if err = os.WriteFile(filepath.Join(dir2, "empty-file"), []byte{}, 0o644); err != nil {
 		t.Fatalf("Unable create test file. %v", err)
 	}
 

--- a/ellipses/ellipses_test.go
+++ b/ellipses/ellipses_test.go
@@ -234,7 +234,7 @@ func TestFindEllipsesPatterns(t *testing.T) {
 				repl := func(v interface{}) string {
 					s := fmt.Sprintf("%#v", v)
 					// Clean up unneeded declarations
-					s = strings.Replace(s, `[]string{"`, `{"`, -1)
+					s = strings.ReplaceAll(s, `[]string{"`, `{"`)
 					return s
 				}
 				if !reflect.DeepEqual(got, testCase.want) {

--- a/ellipses/list_test.go
+++ b/ellipses/list_test.go
@@ -169,7 +169,7 @@ func TestFindListPatterns(t *testing.T) {
 				repl := func(v interface{}) string {
 					s := fmt.Sprintf("%#v", v)
 					// Clean up unneeded declarations
-					s = strings.Replace(s, `[]string{"`, `{"`, -1)
+					s = strings.ReplaceAll(s, `[]string{"`, `{"`)
 					return s
 				}
 				if !reflect.DeepEqual(got, testCase.want) {

--- a/env/web_env.go
+++ b/env/web_env.go
@@ -23,7 +23,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -150,7 +150,7 @@ func getEnvValueFromHTTP(urlStr, envKey string) (string, string, string, error) 
 		return "", "", "", err
 	}
 
-	envValueBytes, err := ioutil.ReadAll(resp.Body)
+	envValueBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/mimedb/util/gen-db.go
+++ b/mimedb/util/gen-db.go
@@ -23,7 +23,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -80,7 +79,7 @@ func convertDB(jsonFile string) (mimeDB, error) {
 	}
 
 	// Access embedded "db.json" inside go-bindata.
-	jsonDB, err := ioutil.ReadFile(jsonFile)
+	jsonDB, err := os.ReadFile(jsonFile)
 	if err != nil {
 		return nil, err
 	}

--- a/net/port.go
+++ b/net/port.go
@@ -48,9 +48,10 @@ func GetFreePort() (Port, error) {
 
 // ParsePort - parses string into Port
 func ParsePort(s string) (p Port, err error) {
-	if s == "https" {
+	switch s {
+	case "https":
 		return Port(443), nil
-	} else if s == "http" {
+	case "http":
 		return Port(80), nil
 	}
 

--- a/policy/condition/stringfunc.go
+++ b/policy/condition/stringfunc.go
@@ -33,7 +33,7 @@ func substitute(values map[string][]string) func(string) string {
 		for _, key := range CommonKeys {
 			// Empty values are not supported for policy variables.
 			if rvalues, ok := values[key.Name()]; ok && rvalues[0] != "" {
-				v = strings.Replace(v, key.VarName(), rvalues[0], -1)
+				v = strings.ReplaceAll(v, key.VarName(), rvalues[0])
 			}
 		}
 		return v

--- a/quick/encoding.go
+++ b/quick/encoding.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -117,7 +116,7 @@ func saveFileConfig(filename string, v interface{}) error {
 		return err
 	}
 	if runtime.GOOS == "windows" {
-		dataBytes = []byte(strings.Replace(string(dataBytes), "\n", "\r\n", -1))
+		dataBytes = []byte(strings.ReplaceAll(string(dataBytes), "\n", "\r\n"))
 	}
 	// Save data.
 	return writeFile(filename, dataBytes)
@@ -132,7 +131,7 @@ func saveFileConfigEtcd(filename string, clnt *etcd.Client, v interface{}) error
 		return err
 	}
 	if runtime.GOOS == "windows" {
-		dataBytes = []byte(strings.Replace(string(dataBytes), "\n", "\r\n", -1))
+		dataBytes = []byte(strings.ReplaceAll(string(dataBytes), "\n", "\r\n"))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -164,7 +163,7 @@ func loadFileConfigEtcd(filename string, clnt *etcd.Client, v interface{}) error
 		if string(ev.Key) == filename {
 			fileData := ev.Value
 			if runtime.GOOS == "windows" {
-				fileData = bytes.Replace(fileData, []byte("\r\n"), []byte("\n"), -1)
+				fileData = bytes.ReplaceAll(fileData, []byte("\r\n"), []byte("\n"))
 			}
 			// Unmarshal file's content
 			return toUnmarshaller(filepath.Ext(filename))(fileData, v)
@@ -177,12 +176,12 @@ func loadFileConfigEtcd(filename string, clnt *etcd.Client, v interface{}) error
 // decoder format according to the filename extension. If no
 // extension is provided, json will be selected by default.
 func loadFileConfig(filename string, v interface{}) error {
-	fileData, err := ioutil.ReadFile(filename)
+	fileData, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
 	if runtime.GOOS == "windows" {
-		fileData = []byte(strings.Replace(string(fileData), "\r\n", "\n", -1))
+		fileData = []byte(strings.ReplaceAll(string(fileData), "\r\n", "\n"))
 	}
 
 	// Unmarshal file's content

--- a/quick/quick.go
+++ b/quick/quick.go
@@ -20,7 +20,6 @@ package quick
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sync"
@@ -73,7 +72,7 @@ func (d config) Save(filename string) error {
 	}
 
 	// Backup if given file exists
-	oldData, err := ioutil.ReadFile(filename)
+	oldData, err := os.ReadFile(filename)
 	if err != nil {
 		// Ignore if file does not exist.
 		if !os.IsNotExist(err) {

--- a/quick/quick_test.go
+++ b/quick/quick_test.go
@@ -20,7 +20,6 @@ package quick
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"runtime"
@@ -61,7 +60,7 @@ func TestReadVersionErr(t *testing.T) {
 		t.Fatal("Unexpected should fail in initialization for bad input")
 	}
 
-	err = ioutil.WriteFile("test.json", []byte("{ \"version\":2,"), 0o644)
+	err = os.WriteFile("test.json", []byte("{ \"version\":2,"), 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +70,7 @@ func TestReadVersionErr(t *testing.T) {
 		t.Fatal("Unexpected should fail to fetch version")
 	}
 
-	err = ioutil.WriteFile("test.json", []byte("{ \"version\":2 }"), 0o644)
+	err = os.WriteFile("test.json", []byte("{ \"version\":2 }"), 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +230,7 @@ directories:
 `
 
 	if runtime.GOOS == "windows" {
-		plainYAML = strings.Replace(plainYAML, "\n", "\r\n", -1)
+		plainYAML = strings.ReplaceAll(plainYAML, "\n", "\r\n")
 	}
 
 	saveMe := myStruct{"1", "guest", "nopassword", []string{"Work", "Documents", "Music"}}
@@ -248,7 +247,7 @@ directories:
 	}
 
 	// Check if the saved structure in actually an YAML format
-	b, err := ioutil.ReadFile(testYAML)
+	b, err := os.ReadFile(testYAML)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +296,7 @@ func TestJSONFormat(t *testing.T) {
 }`
 
 	if runtime.GOOS == "windows" {
-		plainJSON = strings.Replace(plainJSON, "\n", "\r\n", -1)
+		plainJSON = strings.ReplaceAll(plainJSON, "\n", "\r\n")
 	}
 
 	saveMe := myStruct{"1", "guest", "nopassword", []string{"Work", "Documents", "Music"}}
@@ -314,7 +313,7 @@ func TestJSONFormat(t *testing.T) {
 	}
 
 	// Check if the saved structure in actually an JSON format
-	b, err := ioutil.ReadFile(testJSON)
+	b, err := os.ReadFile(testJSON)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/safe/safe.go
+++ b/safe/safe.go
@@ -19,7 +19,6 @@ package safe
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -117,7 +116,7 @@ func CreateFile(name string) (*File, error) {
 	}
 
 	fname := filepath.Base(name)
-	tmpfile, err := ioutil.TempFile(dname, "$tmpfile."+fname+".")
+	tmpfile, err := os.CreateTemp(dname, "$tmpfile."+fname+".")
 	if err != nil {
 		return nil, err
 	}

--- a/safe/safe_test.go
+++ b/safe/safe_test.go
@@ -18,7 +18,6 @@
 package safe
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -29,7 +28,7 @@ type MySuite struct {
 }
 
 func (s *MySuite) SetUpSuite(t *testing.T) {
-	root, err := ioutil.TempDir(os.TempDir(), "safe_test.go.")
+	root, err := os.MkdirTemp(os.TempDir(), "safe_test.go.")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sys/threads.go
+++ b/sys/threads.go
@@ -21,14 +21,14 @@
 package sys
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
 
 // GetMaxThreads returns the maximum number of threads that the system can create.
 func GetMaxThreads() (int, error) {
-	sysMaxThreadsStr, err := ioutil.ReadFile("/proc/sys/kernel/threads-max")
+	sysMaxThreadsStr, err := os.ReadFile("/proc/sys/kernel/threads-max")
 	if err != nil {
 		return 0, err
 	}

--- a/xtime/time_contrib.go
+++ b/xtime/time_contrib.go
@@ -42,7 +42,7 @@ func parseDuration(s string) (time.Duration, error) {
 		var err error
 
 		// The next character must be [0-9.]
-		if !(s[0] == '.' || '0' <= s[0] && s[0] <= '9') {
+		if s[0] != '.' && (s[0] < '0' || s[0] > '9') {
 			return 0, errors.New("invalid duration " + strconv.Quote(orig))
 		}
 		// Consume [0-9]*


### PR DESCRIPTION
This PR upgrades the Golang CI linter to v2. It also introduced some new rules, so also fixed the new linter issues (or surpressed them in the configuration).