### PR TITLE
chore: Get Next Immediate Port

### DIFF
--- a/net/port.go
+++ b/net/port.go
@@ -46,6 +46,25 @@ func GetFreePort() (Port, error) {
 	return Port(l.Addr().(*net.TCPAddr).Port), nil
 }
 
+// GetNextPort returns the immediate next port if it's available.
+func GetNextPort(port string) (Port, error) {
+	if port == "" || port == "0" {
+		return 0, errors.New("invalid starting port")
+	}
+	p, err := strconv.Atoi(port)
+	if err != nil || p <= 0 {
+		return 0, errors.New("invalid port number")
+	}
+	nextPort := p + 1
+	addr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: nextPort}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return Port(l.Addr().(*net.TCPAddr).Port), nil
+}
+
 // ParsePort - parses string into Port
 func ParsePort(s string) (p Port, err error) {
 	switch s {

--- a/net/port.go
+++ b/net/port.go
@@ -46,8 +46,8 @@ func GetFreePort() (Port, error) {
 	return Port(l.Addr().(*net.TCPAddr).Port), nil
 }
 
-// GetNextPort returns the immediate next port if it's available.
-func GetNextPort(port string) (Port, error) {
+// GetNextFreePort returns the immediate next port if it's available.
+func GetNextFreePort(port string) (Port, error) {
 	if port == "" || port == "0" {
 		return 0, errors.New("invalid starting port")
 	}

--- a/net/port.go
+++ b/net/port.go
@@ -46,8 +46,7 @@ func GetFreePort() (Port, error) {
 	return Port(l.Addr().(*net.TCPAddr).Port), nil
 }
 
-// GetNextPort returns the immediate next port if it's available.
-// The maximum allowed input is 65534, since we increment the value by 1.
+// GetNextFreePort - returns the immediate next port if it's available. The maximum allowed input is 65534, since we increment the value by 1.
 func GetNextFreePort(port string) (Port, error) {
 	if port == "" || port == "0" {
 		return 0, errors.New("invalid starting port")

--- a/net/port.go
+++ b/net/port.go
@@ -46,14 +46,15 @@ func GetFreePort() (Port, error) {
 	return Port(l.Addr().(*net.TCPAddr).Port), nil
 }
 
-// GetNextFreePort returns the immediate next port if it's available.
+// GetNextPort returns the immediate next port if it's available.
+// The maximum allowed input is 65534, since we increment the value by 1.
 func GetNextFreePort(port string) (Port, error) {
 	if port == "" || port == "0" {
 		return 0, errors.New("invalid starting port")
 	}
 	p, err := strconv.Atoi(port)
-	if err != nil || p <= 0 {
-		return 0, errors.New("invalid port number")
+	if err != nil || p <= 0 || p >= 65535 {
+		return 0, errors.New("invalid port number (must be between 1 and 65534)")
 	}
 	nextPort := p + 1
 	addr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: nextPort}


### PR DESCRIPTION
Context: https://github.com/miniohq/eos/issues/646 - This change introduces a reusable function for use in https://github.com/miniohq/eos/pull/649.