### PR TITLE
Add missing inspect data action

### DIFF
--- a/policy/admin-action.go
+++ b/policy/admin-action.go
@@ -243,6 +243,7 @@ var supportedAdminActions = map[AdminAction]struct{}{
 	ServerInfoAdminAction:            {},
 	HealthInfoAdminAction:            {},
 	BandwidthMonitorAction:           {},
+	InspectDataAction:                {},
 	ServerUpdateAdminAction:          {},
 	ServiceRestartAdminAction:        {},
 	ServiceStopAdminAction:           {},


### PR DESCRIPTION
Trying to add a policy with admin:InspectData returns error