### PR TITLE
adding admin:NodeList, NodeInfo and DriveList

### DIFF
--- a/policy/admin-action.go
+++ b/policy/admin-action.go
@@ -227,6 +227,9 @@ const (
 	// SetInfoAction - allow set specific summary and detail
 	SetInfoAction = "admin:SetInfo"
 
+	// DriveListAction - allow listing of drives
+	DriveListAction = "admin:DriveList"
+
 	// DriveInfoAction - allow drive specific summary and detail
 	DriveInfoAction = "admin:DriveInfo"
 

--- a/policy/admin-action.go
+++ b/policy/admin-action.go
@@ -218,6 +218,12 @@ const (
 	// PoolInfoAction - allow pool specific summary and detail information
 	PoolInfoAction = "admin:PoolInfo"
 
+	// NodeListAction - allow listing of nodes
+	NodeListAction = "admin:NodeList"
+
+	// NodeInfoAction - allow node specific summary and detailed information
+	NodeInfoAction = "admin:NodeInfo"
+
 	// SetInfoAction - allow set specific summary and detail
 	SetInfoAction = "admin:SetInfo"
 

--- a/policy/admin-action.go
+++ b/policy/admin-action.go
@@ -307,6 +307,15 @@ var supportedAdminActions = map[AdminAction]struct{}{
 	StartBatchJobAction:    {},
 	CancelBatchJobAction:   {},
 
+	ClusterInfoAction: {},
+	PoolListAction:    {},
+	PoolInfoAction:    {},
+	NodeListAction:    {},
+	NodeInfoAction:    {},
+	SetInfoAction:     {},
+	DriveListAction:   {},
+	DriveInfoAction:   {},
+
 	AllAdminActions: {},
 }
 


### PR DESCRIPTION
Adding NodeList, NodeInfo and DriveList

DriveList is currently not in use inside minio, but will be implemented with the new v4 apis