### PR TITLE
Add serial and parallel multi-policy evaluation

### DIFF
--- a/policy/statement.go
+++ b/policy/statement.go
@@ -45,6 +45,11 @@ var smallBufPool = sync.Pool{
 
 // IsAllowed - checks given policy args is allowed to continue the Rest API.
 func (statement Statement) IsAllowed(args Args) bool {
+	return statement.IsAllowedPtr(&args)
+}
+
+// IsAllowedPtr - checks given policy args is allowed to continue the Rest API.
+func (statement Statement) IsAllowedPtr(args *Args) bool {
 	check := func() bool {
 		if (!statement.Actions.Match(args.Action) && !statement.Actions.IsEmpty()) ||
 			statement.NotActions.Match(args.Action) {


### PR DESCRIPTION
Benchmark compares policy evaluation of multiple policies with the existing merge and evaluate strategy vs the parallel evaluation strategy implemented in this change.

```
goos: linux
goarch: amd64
pkg: github.com/minio/pkg/v3/policy
cpu: 12th Gen Intel(R) Core(TM) i7-1280P
BenchmarkMergeEvalVsParEval
BenchmarkMergeEvalVsParEval/TestCase_0_1p_10a
BenchmarkMergeEvalVsParEval/TestCase_0_1p_10a/MergeAndEval
BenchmarkMergeEvalVsParEval/TestCase_0_1p_10a/MergeAndEval-20         	  503557	      2303 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_0_1p_10a/ParallelEval
BenchmarkMergeEvalVsParEval/TestCase_0_1p_10a/ParallelEval-20         	  349196	      3235 ns/op	    1440 B/op	      10 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_1_2p_10a
BenchmarkMergeEvalVsParEval/TestCase_1_2p_10a/MergeAndEval
BenchmarkMergeEvalVsParEval/TestCase_1_2p_10a/MergeAndEval-20         	   22993	     47299 ns/op	    8160 B/op	      90 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_1_2p_10a/ParallelEval
BenchmarkMergeEvalVsParEval/TestCase_1_2p_10a/ParallelEval-20         	   14168	     83265 ns/op	    7846 B/op	      90 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_2_4p_10a
BenchmarkMergeEvalVsParEval/TestCase_2_4p_10a/MergeAndEval
BenchmarkMergeEvalVsParEval/TestCase_2_4p_10a/MergeAndEval-20         	   13412	     83567 ns/op	   13281 B/op	     130 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_2_4p_10a/ParallelEval
BenchmarkMergeEvalVsParEval/TestCase_2_4p_10a/ParallelEval-20         	    8072	    130524 ns/op	    9762 B/op	     110 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_3_8p_10a
BenchmarkMergeEvalVsParEval/TestCase_3_8p_10a/MergeAndEval
BenchmarkMergeEvalVsParEval/TestCase_3_8p_10a/MergeAndEval-20         	    7324	    168557 ns/op	   40003 B/op	     220 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_3_8p_10a/ParallelEval
BenchmarkMergeEvalVsParEval/TestCase_3_8p_10a/ParallelEval-20         	    5422	    237309 ns/op	   13606 B/op	     150 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_4_64p_10a
BenchmarkMergeEvalVsParEval/TestCase_4_64p_10a/MergeAndEval
BenchmarkMergeEvalVsParEval/TestCase_4_64p_10a/MergeAndEval-20        	     913	   1138799 ns/op	  312028 B/op	     340 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_4_64p_10a/ParallelEval
BenchmarkMergeEvalVsParEval/TestCase_4_64p_10a/ParallelEval-20        	     870	   1190546 ns/op	   32500 B/op	     270 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_5_128p_10a
BenchmarkMergeEvalVsParEval/TestCase_5_128p_10a/MergeAndEval
BenchmarkMergeEvalVsParEval/TestCase_5_128p_10a/MergeAndEval-20       	     494	   2335496 ns/op	  620538 B/op	     380 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_5_128p_10a/ParallelEval
BenchmarkMergeEvalVsParEval/TestCase_5_128p_10a/ParallelEval-20       	     496	   2251935 ns/op	   42795 B/op	     270 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_6_512p_10a
BenchmarkMergeEvalVsParEval/TestCase_6_512p_10a/MergeAndEval
BenchmarkMergeEvalVsParEval/TestCase_6_512p_10a/MergeAndEval-20       	     134	   8230820 ns/op	 2500561 B/op	     500 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_6_512p_10a/ParallelEval
BenchmarkMergeEvalVsParEval/TestCase_6_512p_10a/ParallelEval-20       	     156	   7802951 ns/op	  116988 B/op	     270 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_7_1024p_10a
BenchmarkMergeEvalVsParEval/TestCase_7_1024p_10a/MergeAndEval
BenchmarkMergeEvalVsParEval/TestCase_7_1024p_10a/MergeAndEval-20      	      67	  17104767 ns/op	 5177594 B/op	     641 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_7_1024p_10a/ParallelEval
BenchmarkMergeEvalVsParEval/TestCase_7_1024p_10a/ParallelEval-20      	      82	  14370661 ns/op	  209162 B/op	     270 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_8_4096p_10a
BenchmarkMergeEvalVsParEval/TestCase_8_4096p_10a/MergeAndEval
BenchmarkMergeEvalVsParEval/TestCase_8_4096p_10a/MergeAndEval-20      	      16	  68047020 ns/op	21803010 B/op	    1282 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_8_4096p_10a/ParallelEval
BenchmarkMergeEvalVsParEval/TestCase_8_4096p_10a/ParallelEval-20      	      22	  51123517 ns/op	  839006 B/op	     270 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_9_16384p_10a
BenchmarkMergeEvalVsParEval/TestCase_9_16384p_10a/MergeAndEval
BenchmarkMergeEvalVsParEval/TestCase_9_16384p_10a/MergeAndEval-20     	       4	 289250005 ns/op	87108504 B/op	    3370 allocs/op
BenchmarkMergeEvalVsParEval/TestCase_9_16384p_10a/ParallelEval
BenchmarkMergeEvalVsParEval/TestCase_9_16384p_10a/ParallelEval-20     	       6	 204048975 ns/op	 2805513 B/op	     271 allocs/op
```

Parallel evaluation is faster when there are more than 128 policies here. The is also more efficient in terms of allocations.