### PR TITLE
Fix linter issues

### DIFF
--- a/ellipses/ellipses.go
+++ b/ellipses/ellipses.go
@@ -42,10 +42,10 @@ var errFormat = errors.New("format error")
 // `{33...64}`
 func parseEllipsesRange(pattern string) (seq []string, err error) {
 	if !strings.Contains(pattern, openBraces) {
-		return nil, errors.New("Invalid argument")
+		return nil, errors.New("invalid argument")
 	}
 	if !strings.Contains(pattern, closeBraces) {
-		return nil, errors.New("Invalid argument")
+		return nil, errors.New("invalid argument")
 	}
 
 	pattern = strings.TrimPrefix(pattern, openBraces)
@@ -53,7 +53,7 @@ func parseEllipsesRange(pattern string) (seq []string, err error) {
 
 	ellipsesRange := strings.Split(pattern, ellipses)
 	if len(ellipsesRange) != 2 {
-		return nil, errors.New("Invalid argument")
+		return nil, errors.New("invalid argument")
 	}
 
 	var hexadecimal bool
@@ -77,7 +77,7 @@ func parseEllipsesRange(pattern string) (seq []string, err error) {
 	}
 
 	if start > end {
-		return nil, fmt.Errorf("Incorrect range start %d cannot be bigger than end %d", start, end)
+		return nil, fmt.Errorf("incorrect range start %d cannot be bigger than end %d", start, end)
 	}
 
 	for i := start; i <= end; i++ {
@@ -167,7 +167,7 @@ func HasEllipses(args ...string) bool {
 
 // ErrInvalidEllipsesFormatFn error returned when invalid ellipses format is detected.
 var ErrInvalidEllipsesFormatFn = func(arg string) error {
-	return fmt.Errorf("Invalid ellipsis format in (%s), Ellipsis range must be provided in format {N...M} where N and M are positive integers, M must be greater than N,  with an allowed minimum range of 4", arg)
+	return fmt.Errorf("invalid ellipsis format in (%s), ellipsis range must be provided in format {N...M} where N and M are positive integers, M must be greater than N,  with an allowed minimum range of 4", arg)
 }
 
 // FindEllipsesPatterns - finds all ellipses patterns, recursively and parses the ranges numerically.

--- a/ellipses/list.go
+++ b/ellipses/list.go
@@ -46,7 +46,7 @@ func HasList(args ...string) bool {
 
 // ErrInvalidListFormatFn error returned when invalid list format is detected.
 var ErrInvalidListFormatFn = func(arg string) error {
-	return fmt.Errorf("Invalid list format in (%s)", arg)
+	return fmt.Errorf("invalid list format in (%s)", arg)
 }
 
 // FindListPatterns - finds all list patterns, recursively and parses the ranges numerically.

--- a/ldap/validation.go
+++ b/ldap/validation.go
@@ -422,15 +422,15 @@ func validateAndParseBaseDNList(conn *ldap.Conn, baseDNList []string) ([]BaseDNI
 	for _, dn := range baseDNList {
 		lookupResult, err := LookupDN(conn, dn, nil)
 		if err != nil {
-			return nil, fmt.Errorf("Base DN `%s` lookup failed: %w", dn, err)
+			return nil, fmt.Errorf("base DN `%s` lookup failed: %w", dn, err)
 		}
 		if lookupResult == nil {
-			return nil, fmt.Errorf("Base DN `%s` not found in the LDAP server", dn)
+			return nil, fmt.Errorf("base DN `%s` not found in the LDAP server", dn)
 		}
 		serverDN := lookupResult.NormDN
 		parsed, err := ldap.ParseDN(serverDN)
 		if err != nil {
-			return nil, fmt.Errorf("Unexpectedly failed to parse DN `%s`: %w", serverDN, err)
+			return nil, fmt.Errorf("unexpectedly failed to parse DN `%s`: %w", serverDN, err)
 		}
 		res = append(res, BaseDNInfo{Original: dn, ServerDN: serverDN, Parsed: parsed})
 	}
@@ -442,7 +442,7 @@ func parseBaseDNListOffline(baseDNList []string) ([]BaseDNInfo, error) {
 	for _, dn := range baseDNList {
 		parsed, err := ldap.ParseDN(dn)
 		if err != nil {
-			return nil, fmt.Errorf("Unexpectedly failed to parse DN `%s`: %w", dn, err)
+			return nil, fmt.Errorf("unexpectedly failed to parse DN `%s`: %w", dn, err)
 		}
 		res = append(res, BaseDNInfo{Original: dn, Parsed: parsed})
 	}
@@ -456,7 +456,7 @@ var validAttributeRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]*$`)
 func validateAttributes(attrs []string) error {
 	for _, attr := range attrs {
 		if !validAttributeRegex.MatchString(attr) {
-			return fmt.Errorf("Attribute name `%s` is invalid", attr)
+			return fmt.Errorf("attribute name `%s` is invalid", attr)
 		}
 	}
 	return nil

--- a/licverifier/verifier.go
+++ b/licverifier/verifier.go
@@ -101,7 +101,7 @@ func parseECPublicKeyFromPEM(key []byte) (*ecdsa.PublicKey, error) {
 func NewLicenseVerifier(pemBytes []byte) (*LicenseVerifier, error) {
 	pbKey, err := parseECPublicKeyFromPEM(pemBytes)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse public key: %s", err)
+		return nil, fmt.Errorf("failed to parse public key: %w", err)
 	}
 	key, err := jwk.FromRaw(pbKey)
 	if err != nil {
@@ -124,7 +124,7 @@ func toLicenseInfo(license string, token jwt.Token) (LicenseInfo, error) {
 	}
 	accID, ok := claims[accountID].(float64)
 	if !ok || ok && accID < 0 {
-		return LicenseInfo{}, errors.New("Invalid accountId in claims")
+		return LicenseInfo{}, errors.New("invalid accountId in claims")
 	}
 
 	// deployment id may not be present in older licenses.
@@ -137,19 +137,19 @@ func toLicenseInfo(license string, token jwt.Token) (LicenseInfo, error) {
 
 	orgName, ok := claims[organization].(string)
 	if !ok {
-		return LicenseInfo{}, errors.New("Invalid organization in claims")
+		return LicenseInfo{}, errors.New("invalid organization in claims")
 	}
 	storageCap, ok := claims[capacity].(float64)
 	if !ok {
-		return LicenseInfo{}, errors.New("Invalid storage capacity in claims")
+		return LicenseInfo{}, errors.New("invalid storage capacity in claims")
 	}
 	plan, ok := claims[plan].(string)
 	if !ok {
-		return LicenseInfo{}, errors.New("Invalid plan in claims")
+		return LicenseInfo{}, errors.New("invalid plan in claims")
 	}
 	iAt, ok := claims[issuedAt].(time.Time)
 	if !ok {
-		return LicenseInfo{}, errors.New("Invalid issuedAt in claims")
+		return LicenseInfo{}, errors.New("invalid issuedAt in claims")
 	}
 
 	// apiKey is optional as it's not present in older licenses

--- a/quick/encoding.go
+++ b/quick/encoding.go
@@ -59,10 +59,10 @@ func (j jsonEncoding) Unmarshal(b []byte, v interface{}) error {
 		// Try to return a sophisticated json error message if possible
 		switch jerr := err.(type) {
 		case *json.SyntaxError:
-			return fmt.Errorf("Unable to parse JSON schema due to a syntax error at '%s'",
+			return fmt.Errorf("unable to parse JSON schema due to a syntax error at '%s'",
 				FormatJSONSyntaxError(bytes.NewReader(b), jerr.Offset))
 		case *json.UnmarshalTypeError:
-			return fmt.Errorf("Unable to parse JSON, type '%v' cannot be converted into the Go '%v' type",
+			return fmt.Errorf("unable to parse JSON, type '%v' cannot be converted into the Go '%v' type",
 				jerr.Value, jerr.Type)
 		}
 		return err

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -190,7 +190,7 @@ func (s *Server) Listen() (err error) {
 			// it is alright to keep it implemented for consistency.
 			// UPDATE: https://go-review.googlesource.com/c/go/+/340261
 			ne, ok := err.(net.Error)
-			if ok && (ne.Timeout() || ne.Temporary()) {
+			if ok && ne.Timeout() {
 				s.logger.Error(
 					AcceptNetworkError,
 					fmt.Errorf("error accepting connections: %w", err),


### PR DESCRIPTION
## Summary
- fix error capitalization in ellipses helpers
- update list parser error
- replace deprecated LDAP dials with `DialURL`
- normalize LDAP error messages
- normalize validation error messages
- fix licverifier error strings
- fix JSON decoding errors
- drop deprecated Temporary check in SFTP server

## Testing
- `~/go/bin/staticcheck ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685f8be954dc8329844fd58efd91c9eb