### PR TITLE
fix: readonly LDAP user can access "Add User" button

### DIFF
--- a/policy/constants.go
+++ b/policy/constants.go
@@ -60,6 +60,12 @@ var DefaultPolicies = []struct {
 					Actions:   NewActionSet(GetBucketLocationAction, GetObjectAction),
 					Resources: NewResourceSet(NewResource("*")),
 				},
+				{
+					SID:       ID(""),
+					Effect:    Deny,
+					Actions:   NewActionSet(CreateUserAdminAction),
+					Resources: NewResourceSet(NewResource("*")),
+				},
 			},
 		},
 	},


### PR DESCRIPTION
closes issue: https://github.com/miniohq/aistor-console/issues/4107

due to not explictly denying create user action, readonly LDAP user in aistor can access "Add User" button. 

since the https://github.com/minio/pkg/blob/2567be34479e09579aab5f5b47d1aa9875d9f168/policy/policy.go#L159
policy go used on aistor console session controller it's giving create user action permission to readonly LDAP user. 