### PR TITLE
feat: Table tagging related changes

### DIFF
--- a/policy/condition/keyname.go
+++ b/policy/condition/keyname.go
@@ -83,9 +83,6 @@ const (
 	// S3TablesTableTag filters access by tags on the table.
 	S3TablesTableTag KeyName = "s3tables:TableTag"
 
-	// S3TablesViewTag filters access by tags on the view.
-	S3TablesViewTag KeyName = "s3tables:ViewTag"
-
 	// S3XAmzCopySource - key representing x-amz-copy-source HTTP header applicable to PutObject API only.
 	S3XAmzCopySource KeyName = "s3:x-amz-copy-source"
 
@@ -304,7 +301,6 @@ var AllSupportedKeys = []KeyName{
 	S3TablesRegisterLocation,
 	S3TablesWarehouseTag,
 	S3TablesTableTag,
-	S3TablesViewTag,
 	AWSReferer,
 	AWSSourceIP,
 	AWSUserAgent,

--- a/policy/condition/keyname.go
+++ b/policy/condition/keyname.go
@@ -77,6 +77,15 @@ const (
 	// S3TablesRegisterLocation filters access by the metadata location for table/view registration.
 	S3TablesRegisterLocation KeyName = "s3tables:registerLocation"
 
+	// S3TablesWarehouseTag filters access by tags on the table warehouse.
+	S3TablesWarehouseTag KeyName = "s3tables:WarehouseTag"
+
+	// S3TablesTableTag filters access by tags on the table.
+	S3TablesTableTag KeyName = "s3tables:TableTag"
+
+	// S3TablesViewTag filters access by tags on the view.
+	S3TablesViewTag KeyName = "s3tables:ViewTag"
+
 	// S3XAmzCopySource - key representing x-amz-copy-source HTTP header applicable to PutObject API only.
 	S3XAmzCopySource KeyName = "s3:x-amz-copy-source"
 
@@ -293,6 +302,9 @@ var AllSupportedKeys = []KeyName{
 	S3TablesTableName,
 	S3TablesViewName,
 	S3TablesRegisterLocation,
+	S3TablesWarehouseTag,
+	S3TablesTableTag,
+	S3TablesViewTag,
 	AWSReferer,
 	AWSSourceIP,
 	AWSUserAgent,

--- a/policy/table-action.go
+++ b/policy/table-action.go
@@ -302,11 +302,34 @@ func createTableActionConditionKeyMap() map[Action]condition.KeySet {
 	s3TablesKMSKeyKey := condition.S3TablesKMSKeyArn.ToKey()
 	s3TablesSSEAlgorithmKey := condition.S3TablesSSEAlgorithm.ToKey()
 	s3TablesRegisterLocationKey := condition.S3TablesRegisterLocation.ToKey()
+	s3TablesWarehouseTagKey := condition.S3TablesWarehouseTag.ToKey()
+	s3TablesTableTagKey := condition.S3TablesTableTag.ToKey()
+	s3TablesViewTagKey := condition.S3TablesViewTag.ToKey()
 
 	withCommon := func(keys ...condition.Key) condition.KeySet {
 		merged := append([]condition.Key{}, commonKeys...)
 		merged = append(merged, keys...)
 		return condition.NewKeySet(merged...)
+	}
+
+	withWarehouseCommon := func(keys ...condition.Key) condition.KeySet {
+		return withCommon(append([]condition.Key{s3TablesWarehouseTagKey}, keys...)...)
+	}
+
+	withTableCommon := func(keys ...condition.Key) condition.KeySet {
+		return withWarehouseCommon(append([]condition.Key{
+			s3TablesNamespaceKey,
+			s3TablesTableNameKey,
+			s3TablesTableTagKey,
+		}, keys...)...)
+	}
+
+	withViewCommon := func(keys ...condition.Key) condition.KeySet {
+		return withWarehouseCommon(append([]condition.Key{
+			s3TablesNamespaceKey,
+			s3TablesViewNameKey,
+			s3TablesViewTagKey,
+		}, keys...)...)
 	}
 
 	tableActionConditionKeyMap := map[Action]condition.KeySet{}
@@ -322,64 +345,70 @@ func createTableActionConditionKeyMap() map[Action]condition.KeySet {
 		s3TablesKMSKeyKey,
 		s3TablesSSEAlgorithmKey,
 		s3TablesRegisterLocationKey,
+		s3TablesWarehouseTagKey,
+		s3TablesTableTagKey,
+		s3TablesViewTagKey,
 	)
-	tableActionConditionKeyMap[S3TablesCreateNamespaceAction] = withCommon(s3TablesNamespaceKey)
-	tableActionConditionKeyMap[S3TablesCreateTableAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey, s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
+	tableActionConditionKeyMap[S3TablesCreateNamespaceAction] = withWarehouseCommon(s3TablesNamespaceKey)
+	tableActionConditionKeyMap[S3TablesCreateTableAction] = withWarehouseCommon(s3TablesNamespaceKey, s3TablesTableNameKey, s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
 	tableActionConditionKeyMap[S3TablesCreateTableBucketAction] = withCommon(s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
-	tableActionConditionKeyMap[S3TablesDeleteNamespaceAction] = withCommon(s3TablesNamespaceKey)
-	tableActionConditionKeyMap[S3TablesDeleteTableAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesDeleteTableBucketAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesDeleteTableBucketEncryptionAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesDeleteTableBucketPolicyAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesDeleteTablePolicyAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesGetNamespaceAction] = withCommon(s3TablesNamespaceKey)
-	tableActionConditionKeyMap[S3TablesGetTableAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesGetTableBucketAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesGetTableBucketEncryptionAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesGetTableBucketMaintenanceConfigurationAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesGetTableBucketPolicyAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesGetTableDataAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesGetTableEncryptionAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesGetTableMaintenanceConfigurationAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesGetTableMaintenanceJobStatusAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesGetTableMetadataLocationAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesGetTablePolicyAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesListNamespacesAction] = withCommon(s3TablesNamespaceKey)
+	tableActionConditionKeyMap[S3TablesDeleteNamespaceAction] = withWarehouseCommon(s3TablesNamespaceKey)
+	tableActionConditionKeyMap[S3TablesDeleteTableAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesDeleteTableBucketAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesDeleteTableBucketEncryptionAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesDeleteTableBucketPolicyAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesDeleteTablePolicyAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesGetNamespaceAction] = withWarehouseCommon(s3TablesNamespaceKey)
+	tableActionConditionKeyMap[S3TablesGetTableAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesGetTableBucketAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesGetTableBucketEncryptionAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesGetTableBucketMaintenanceConfigurationAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesGetTableBucketPolicyAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesGetTableDataAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesGetTableEncryptionAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesGetTableMaintenanceConfigurationAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesGetTableMaintenanceJobStatusAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesGetTableMetadataLocationAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesGetTablePolicyAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesListNamespacesAction] = withWarehouseCommon(s3TablesNamespaceKey)
 	tableActionConditionKeyMap[S3TablesListTableBucketsAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesListTablesAction] = withCommon(s3TablesNamespaceKey)
-	tableActionConditionKeyMap[S3TablesPutTableBucketEncryptionAction] = withCommon(s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
-	tableActionConditionKeyMap[S3TablesPutTableBucketMaintenanceConfigurationAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesPutTableBucketPolicyAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesPutTableDataAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesPutTableEncryptionAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey, s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
-	tableActionConditionKeyMap[S3TablesPutTableMaintenanceConfigurationAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesPutTablePolicyAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesRegisterTableAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey, s3TablesRegisterLocationKey)
-	tableActionConditionKeyMap[S3TablesRenameTableAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesUpdateTableMetadataLocationAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
+	tableActionConditionKeyMap[S3TablesListTablesAction] = withWarehouseCommon(s3TablesNamespaceKey)
+	tableActionConditionKeyMap[S3TablesPutTableBucketEncryptionAction] = withWarehouseCommon(s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
+	tableActionConditionKeyMap[S3TablesPutTableBucketMaintenanceConfigurationAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesPutTableBucketPolicyAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesPutTableDataAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesPutTableEncryptionAction] = withTableCommon(s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
+	tableActionConditionKeyMap[S3TablesPutTableMaintenanceConfigurationAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesPutTablePolicyAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesRegisterTableAction] = withTableCommon(s3TablesRegisterLocationKey)
+	tableActionConditionKeyMap[S3TablesRenameTableAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesUpdateTableMetadataLocationAction] = withTableCommon()
 	tableActionConditionKeyMap[S3TablesCreateWarehouseAction] = withCommon(s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
-	tableActionConditionKeyMap[S3TablesDeleteWarehouseAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesDeleteWarehouseEncryptionAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesDeleteWarehousePolicyAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesGetWarehouseAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesGetWarehouseEncryptionAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesGetWarehouseMaintenanceConfigurationAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesGetWarehousePolicyAction] = withCommon()
+	tableActionConditionKeyMap[S3TablesDeleteWarehouseAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesDeleteWarehouseEncryptionAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesDeleteWarehousePolicyAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesGetWarehouseAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesGetWarehouseEncryptionAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesGetWarehouseMaintenanceConfigurationAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesGetWarehousePolicyAction] = withWarehouseCommon()
 	tableActionConditionKeyMap[S3TablesListWarehousesAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesPutWarehouseEncryptionAction] = withCommon(s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
-	tableActionConditionKeyMap[S3TablesPutWarehouseMaintenanceConfigurationAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesPutWarehousePolicyAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesGetConfigAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesTableMetricsAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesUpdateTableAction] = withCommon(s3TablesNamespaceKey, s3TablesTableNameKey)
-	tableActionConditionKeyMap[S3TablesCreateViewAction] = withCommon(s3TablesNamespaceKey, s3TablesViewNameKey)
-	tableActionConditionKeyMap[S3TablesDeleteViewAction] = withCommon(s3TablesNamespaceKey, s3TablesViewNameKey)
-	tableActionConditionKeyMap[S3TablesGetViewAction] = withCommon(s3TablesNamespaceKey, s3TablesViewNameKey)
-	tableActionConditionKeyMap[S3TablesRenameViewAction] = withCommon(s3TablesNamespaceKey, s3TablesViewNameKey)
-	tableActionConditionKeyMap[S3TablesUpdateViewAction] = withCommon(s3TablesNamespaceKey, s3TablesViewNameKey)
-	tableActionConditionKeyMap[S3TablesRegisterViewAction] = withCommon(s3TablesNamespaceKey, s3TablesViewNameKey, s3TablesRegisterLocationKey)
-	tableActionConditionKeyMap[S3TablesListViewsAction] = withCommon(s3TablesNamespaceKey)
-	tableActionConditionKeyMap[S3TablesUpdateNamespacePropertiesAction] = withCommon(s3TablesNamespaceKey)
+	tableActionConditionKeyMap[S3TablesPutWarehouseEncryptionAction] = withWarehouseCommon(s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
+	tableActionConditionKeyMap[S3TablesPutWarehouseMaintenanceConfigurationAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesPutWarehousePolicyAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesGetConfigAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesTableMetricsAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesUpdateTableAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesCreateViewAction] = withWarehouseCommon(s3TablesNamespaceKey, s3TablesViewNameKey)
+	tableActionConditionKeyMap[S3TablesDeleteViewAction] = withViewCommon()
+	tableActionConditionKeyMap[S3TablesGetViewAction] = withViewCommon()
+	tableActionConditionKeyMap[S3TablesRenameViewAction] = withViewCommon()
+	tableActionConditionKeyMap[S3TablesUpdateViewAction] = withViewCommon()
+	tableActionConditionKeyMap[S3TablesRegisterViewAction] = withViewCommon(s3TablesRegisterLocationKey)
+	tableActionConditionKeyMap[S3TablesListViewsAction] = withWarehouseCommon(s3TablesNamespaceKey)
+	tableActionConditionKeyMap[S3TablesUpdateNamespacePropertiesAction] = withWarehouseCommon(s3TablesNamespaceKey)
+	// TODO: the *Resource tag actions can target a warehouse, table, or view.
+	// They are scoped to warehouse common for now; revisit which resource-specific
+	// keys (namespace, table/view name, and table/view tags) each should accept.
 	tableActionConditionKeyMap[S3TablesTagResourceAction] = withCommon()
 	tableActionConditionKeyMap[S3TablesUntagResourceAction] = withCommon()
 	tableActionConditionKeyMap[S3TablesListTagsForResourceAction] = withCommon()

--- a/policy/table-action.go
+++ b/policy/table-action.go
@@ -208,12 +208,19 @@ const (
 	// S3TablesUpdateNamespacePropertiesAction is a MinIO extension for updating namespace properties.
 	S3TablesUpdateNamespacePropertiesAction = "s3tables:UpdateNamespaceProperties"
 
-	// S3TablesTagResourceAction maps to the AWS `s3tables:TagResource` action.
-	S3TablesTagResourceAction = "s3tables:TagResource"
-	// S3TablesUntagResourceAction maps to the AWS `s3tables:UntagResource` action.
-	S3TablesUntagResourceAction = "s3tables:UntagResource"
-	// S3TablesListTagsForResourceAction maps to the AWS `s3tables:ListTagsForResource` action.
-	S3TablesListTagsForResourceAction = "s3tables:ListTagsForResource"
+	// S3TablesTagWarehouseAction is a MinIO extension for tagging Iceberg warehouses.
+	S3TablesTagWarehouseAction = "s3tables:TagWarehouse"
+	// S3TablesUntagWarehouseAction is a MinIO extension for removing tags from Iceberg warehouses.
+	S3TablesUntagWarehouseAction = "s3tables:UntagWarehouse"
+	// S3TablesListTagsForWarehouseAction is a MinIO extension for listing tags on Iceberg warehouses.
+	S3TablesListTagsForWarehouseAction = "s3tables:ListTagsForWarehouse"
+
+	// S3TablesTagTableAction is a MinIO extension for tagging tables.
+	S3TablesTagTableAction = "s3tables:TagTable"
+	// S3TablesUntagTableAction is a MinIO extension for removing tags from tables.
+	S3TablesUntagTableAction = "s3tables:UntagTable"
+	// S3TablesListTagsForTableAction is a MinIO extension for listing tags on tables.
+	S3TablesListTagsForTableAction = "s3tables:ListTagsForTable"
 
 	// AllS3TablesActions - all Amazon S3 Tables actions
 	AllS3TablesActions = "s3tables:*"
@@ -278,9 +285,12 @@ var SupportedTableActions = map[TableAction]struct{}{
 	S3TablesListViewsAction:                              {},
 	S3TablesRegisterViewAction:                           {},
 	S3TablesUpdateNamespacePropertiesAction:              {},
-	S3TablesTagResourceAction:                            {},
-	S3TablesUntagResourceAction:                          {},
-	S3TablesListTagsForResourceAction:                    {},
+	S3TablesTagWarehouseAction:                           {},
+	S3TablesUntagWarehouseAction:                         {},
+	S3TablesListTagsForWarehouseAction:                   {},
+	S3TablesTagTableAction:                               {},
+	S3TablesUntagTableAction:                             {},
+	S3TablesListTagsForTableAction:                       {},
 	AllS3TablesActions:                                   {},
 }
 
@@ -304,7 +314,6 @@ func createTableActionConditionKeyMap() map[Action]condition.KeySet {
 	s3TablesRegisterLocationKey := condition.S3TablesRegisterLocation.ToKey()
 	s3TablesWarehouseTagKey := condition.S3TablesWarehouseTag.ToKey()
 	s3TablesTableTagKey := condition.S3TablesTableTag.ToKey()
-	s3TablesViewTagKey := condition.S3TablesViewTag.ToKey()
 
 	withCommon := func(keys ...condition.Key) condition.KeySet {
 		merged := append([]condition.Key{}, commonKeys...)
@@ -328,7 +337,6 @@ func createTableActionConditionKeyMap() map[Action]condition.KeySet {
 		return withWarehouseCommon(append([]condition.Key{
 			s3TablesNamespaceKey,
 			s3TablesViewNameKey,
-			s3TablesViewTagKey,
 		}, keys...)...)
 	}
 
@@ -347,7 +355,6 @@ func createTableActionConditionKeyMap() map[Action]condition.KeySet {
 		s3TablesRegisterLocationKey,
 		s3TablesWarehouseTagKey,
 		s3TablesTableTagKey,
-		s3TablesViewTagKey,
 	)
 	tableActionConditionKeyMap[S3TablesCreateNamespaceAction] = withWarehouseCommon(s3TablesNamespaceKey)
 	tableActionConditionKeyMap[S3TablesCreateTableAction] = withWarehouseCommon(s3TablesNamespaceKey, s3TablesTableNameKey, s3TablesKMSKeyKey, s3TablesSSEAlgorithmKey)
@@ -406,12 +413,12 @@ func createTableActionConditionKeyMap() map[Action]condition.KeySet {
 	tableActionConditionKeyMap[S3TablesRegisterViewAction] = withViewCommon(s3TablesRegisterLocationKey)
 	tableActionConditionKeyMap[S3TablesListViewsAction] = withWarehouseCommon(s3TablesNamespaceKey)
 	tableActionConditionKeyMap[S3TablesUpdateNamespacePropertiesAction] = withWarehouseCommon(s3TablesNamespaceKey)
-	// TODO: the *Resource tag actions can target a warehouse, table, or view.
-	// They are scoped to warehouse common for now; revisit which resource-specific
-	// keys (namespace, table/view name, and table/view tags) each should accept.
-	tableActionConditionKeyMap[S3TablesTagResourceAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesUntagResourceAction] = withCommon()
-	tableActionConditionKeyMap[S3TablesListTagsForResourceAction] = withCommon()
+	tableActionConditionKeyMap[S3TablesTagWarehouseAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesUntagWarehouseAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesListTagsForWarehouseAction] = withWarehouseCommon()
+	tableActionConditionKeyMap[S3TablesTagTableAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesUntagTableAction] = withTableCommon()
+	tableActionConditionKeyMap[S3TablesListTagsForTableAction] = withTableCommon()
 
 	return tableActionConditionKeyMap
 }


### PR DESCRIPTION
- Adds `WarehouseTag` and `TableTag` condition keys
- Replaces `TagResourceAction`, untag, and list with `TagTableAction` and `TagWarehouseAction`
- Adds withWarehouseCommon, withTableCommon, and withViewCommon for condition key map creation to centralzie the most common conditon key sets.

See https://github.com/miniohq/aistor/pull/5687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IAM condition keys for S3 Tables warehouse and table tagging.
  * Added policy actions for tagging, untagging, and listing tags on S3 Tables warehouses and tables.

* **Chores**
  * Removed legacy resource-level tagging actions in favor of dedicated warehouse and table operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->