### PR TITLE
feat: add S3 object annotation IAM actions and condition key

### DIFF
--- a/policy/action.go
+++ b/policy/action.go
@@ -175,6 +175,18 @@ const (
 	// DeleteObjectTaggingAction - Delete Object Tags API action
 	DeleteObjectTaggingAction = "s3:DeleteObjectTagging"
 
+	// PutObjectAnnotationAction - PutObjectAnnotation API action
+	PutObjectAnnotationAction = "s3:PutObjectAnnotation"
+
+	// GetObjectAnnotationAction - GetObjectAnnotation API action
+	GetObjectAnnotationAction = "s3:GetObjectAnnotation"
+
+	// DeleteObjectAnnotationAction - DeleteObjectAnnotation API action
+	DeleteObjectAnnotationAction = "s3:DeleteObjectAnnotation"
+
+	// ListObjectAnnotationsAction - ListObjectAnnotations API action
+	ListObjectAnnotationsAction = "s3:ListObjectAnnotations"
+
 	// UpdateObjectEncryptionAction - UpdateObjectEncryption REST API action
 	UpdateObjectEncryptionAction = "s3:UpdateObjectEncryption"
 
@@ -279,6 +291,10 @@ var SupportedActions = map[Action]struct{}{
 	GetObjectTaggingAction:                 {},
 	PutObjectTaggingAction:                 {},
 	DeleteObjectTaggingAction:              {},
+	PutObjectAnnotationAction:              {},
+	GetObjectAnnotationAction:              {},
+	DeleteObjectAnnotationAction:           {},
+	ListObjectAnnotationsAction:            {},
 	UpdateObjectEncryptionAction:           {},
 	PutBucketEncryptionAction:              {},
 	GetBucketEncryptionAction:              {},
@@ -315,6 +331,10 @@ var SupportedObjectActions = map[Action]struct{}{
 	GetObjectTaggingAction:               {},
 	PutObjectTaggingAction:               {},
 	DeleteObjectTaggingAction:            {},
+	PutObjectAnnotationAction:            {},
+	GetObjectAnnotationAction:            {},
+	DeleteObjectAnnotationAction:         {},
+	ListObjectAnnotationsAction:          {},
 	UpdateObjectEncryptionAction:         {},
 	GetObjectVersionAction:               {},
 	GetObjectVersionTaggingAction:        {},
@@ -535,6 +555,28 @@ func createActionConditionKeyMap() ActionConditionKeyMap {
 			append([]condition.Key{
 				condition.S3VersionID.ToKey(),
 				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+
+		PutObjectAnnotationAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+				condition.S3XAmzObjectIfMatch.ToKey(),
+			}, commonKeys...)...),
+		GetObjectAnnotationAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+			}, commonKeys...)...),
+		DeleteObjectAnnotationAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
+				condition.ExistingObjectTag.ToKey(),
+				condition.S3XAmzObjectIfMatch.ToKey(),
+			}, commonKeys...)...),
+		ListObjectAnnotationsAction: condition.NewKeySet(
+			append([]condition.Key{
+				condition.S3VersionID.ToKey(),
 			}, commonKeys...)...),
 
 		UpdateObjectEncryptionAction: condition.NewKeySet(

--- a/policy/condition/keyname.go
+++ b/policy/condition/keyname.go
@@ -103,6 +103,10 @@ const (
 	// HTTP header for S3 API calls
 	S3XAmzServerSideEncryptionAwsKmsKeyID KeyName = "s3:x-amz-server-side-encryption-aws-kms-key-id"
 
+	// S3XAmzObjectIfMatch - key representing the x-amz-object-if-match HTTP header used by the
+	// object annotation APIs (PutObjectAnnotation/DeleteObjectAnnotation) for optimistic concurrency.
+	S3XAmzObjectIfMatch KeyName = "s3:x-amz-object-if-match"
+
 	// S3LocationConstraint - key representing LocationConstraint XML tag of CreateBucket API only.
 	S3LocationConstraint KeyName = "s3:LocationConstraint"
 
@@ -277,6 +281,7 @@ var AllSupportedKeys = []KeyName{
 	S3XAmzMetadataDirective,
 	S3XAmzStorageClass,
 	S3XAmzServerSideEncryptionAwsKmsKeyID,
+	S3XAmzObjectIfMatch,
 	S3XAmzContentSha256,
 	S3LocationConstraint,
 	S3Prefix,


### PR DESCRIPTION
Adds the IAM actions for the S3 object annotation APIs and the condition key needed to gate them.

- Actions: `s3:PutObjectAnnotation`, `s3:GetObjectAnnotation`, `s3:DeleteObjectAnnotation`, `s3:ListObjectAnnotations`
- New condition key: `s3:x-amz-object-if-match` (added to `AllSupportedKeys`)
- Registered in `SupportedActions`, `SupportedObjectActions`, and the action condition-key map (`s3:versionid`, `s3:ExistingObjectTag`, `s3:x-amz-object-if-match` per AWS authorization reference)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for four new S3 actions for object annotations: Put Object Annotation, Get Object Annotation, Delete Object Annotation, and List Object Annotations.
  * Added support for the x-amz-object-if-match condition key for optimistic concurrency control in annotation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->