### PR TITLE
Add MarshalJSON to xtime.Duration

### DIFF
--- a/xtime/time.go
+++ b/xtime/time.go
@@ -18,6 +18,7 @@
 package xtime
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -90,6 +91,11 @@ func (d *Duration) UnmarshalJSON(bs []byte) error {
 	}
 	*d = Duration(dur)
 	return nil
+}
+
+// MarshalJSON implements json.Marshaler - Converts duration to human-readable format (e.g., "2h", "30m")
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
 }
 
 // MarshalMsg appends the marshaled form of the object to the provided

--- a/xtime/time_unmarshal_test.go
+++ b/xtime/time_unmarshal_test.go
@@ -141,4 +141,22 @@ durationPointer: 168h0m1s
 	if string(yamlData) != expected {
 		t.Errorf("Expected:\n%s\nGot:\n%s", expected, string(yamlData))
 	}
+
+	jsonData, err := json.Marshal(&testData)
+	if err != nil {
+		t.Fatalf("Failed to marshal JSON: %v", err)
+	}
+	expectedJSON := `{"a":"1s","dur":"0s","durationPointer":"168h0m1s"}`
+	if string(jsonData) != expectedJSON {
+		t.Errorf("Expected:\n%s\nGot:\n%s", expectedJSON, string(jsonData))
+	}
+
+	// The marshaled JSON must be readable back by UnmarshalJSON.
+	var back testDuration
+	if err := json.Unmarshal(jsonData, &back); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+	if back.A != d1 || back.Dur != d2 || back.DurationPointer == nil || *back.DurationPointer != d3 {
+		t.Errorf("JSON round-trip mismatch: got %+v", back)
+	}
 }


### PR DESCRIPTION
Duration has an UnmarshalJSON that expects a human-readable string (it strips the surrounding quotes and calls ParseDuration), but no MarshalJSON. json.Marshal therefore emits the raw int64 nanoseconds, which UnmarshalJSON cannot read back:

    b, _ := json.Marshal(xtime.Duration(time.Hour))   // "3600000000000"
    var d xtime.Duration
    json.Unmarshal(b, &d)                              // missing unit in duration "60000000000"

The type is documented as supporting YAML and JSON. #136 added MarshalYAML to match the existing UnmarshalYAML; this does the same for JSON, emitting the human-readable string that UnmarshalJSON reads.

Tested with go test -race ./xtime/ (the existing TestDuration_Marshal is extended to cover the JSON marshal output and a round-trip). gofmt, go vet, and golangci-lint are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom durations now serialize to JSON as readable duration strings.
  * Added coverage to ensure duration values round-trip correctly through JSON, including pointer fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->