### PR TITLE
feat: add ActionType generic constraint for policy actions

### DIFF
--- a/policy/action-constraint.go
+++ b/policy/action-constraint.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package policy
+
+// ActionType constrains the set of policy action types. It lets generic helpers
+// accept any typed action — S3 (Action), admin, STS, KMS, Tables, Vectors, or
+// Memory — without forcing callers to convert to Action at each call site. A
+// bare string is intentionally excluded so only real policy action types match.
+type ActionType interface {
+	Action | AdminAction | STSAction | KMSAction | TableAction | VectorsAction | MemoryAction
+}


### PR DESCRIPTION
## Description

Adds `policy.ActionType`, a generic constraint that is the union of the policy
action types:

```go
type ActionType interface {
    Action | AdminAction | STSAction | KMSAction | TableAction | VectorsAction | MemoryAction
}
```

It lets generic auth helpers accept any typed action without forcing callers to
convert to `Action` at each call site, while a bare `string` stays excluded
(so it's tighter than `~string`).

## Motivation

Consumers (e.g. MinIO AIStor) have request-auth helpers typed on `policy.Action`.
As more service action types are added (`TableAction`, `VectorsAction`,
`MemoryAction`, …), callers must wrap each typed constant in `policy.Action(...)`.
A shared constraint lets those helpers become generic over `ActionType` and drop
the per-call conversions, keeping the single `Action` conversion at the boundary
where the policy engine evaluates.

## Changes

- `policy/action-constraint.go` — the `ActionType` union constraint.

No behavior change; type-level addition only. `go build ./...` and
`go vet ./policy/...` pass.