### PR TITLE
feat(policy): add the arn:minio:memory ARN for Memory resources

### DIFF
--- a/policy/memory-resource_test.go
+++ b/policy/memory-resource_test.go
@@ -157,7 +157,7 @@ func TestBareARNPrefixIsNotWildcard(t *testing.T) {
 			t.Errorf("ParseResource(%q): pattern = %q, want empty", prefix, r.Pattern)
 		}
 
-		// Inert: it matches nothing, which is the behaviour already on disk.
+		// Inert: it matches nothing, which is the behavior already on disk.
 		for _, probe := range []string{"bucket", "bucket/key", prefix, "*"} {
 			if r.MatchResource(probe) {
 				t.Errorf("bare %q matched %q; it must match nothing", prefix, probe)
@@ -246,7 +246,7 @@ func TestBareARNPolicyLoadsButCannotBeWritten(t *testing.T) {
 		BucketName:  "secret",
 		ObjectName:  "data",
 	}) {
-		t.Error("behaviour of an already-stored policy changed")
+		t.Error("behavior of an already-stored policy changed")
 	}
 }
 
@@ -385,31 +385,102 @@ func TestMemoryResourceMatch(t *testing.T) {
 	}
 }
 
-// TestMemoryMatchRequiresCleanResource documents a caller contract that is
-// security relevant. Match compares a cleaned resource only on the exact-match
-// fast path; the wildcard fallback sees the raw string. So a resource carrying
-// traversal segments matches a subtree pattern it does not logically belong
-// to. Callers must pass an already-normalized resource path.
-//
-// Patterns cannot carry traversal — IsValid rejects that — so this is purely a
-// constraint on what the server computes from a request.
-func TestMemoryMatchRequiresCleanResource(t *testing.T) {
+// TestMemoryMatchCleansResource covers traversal in the candidate. Match cleans
+// a Memory resource before comparing, so a raw request path cannot escape the
+// subtree its pattern names.
+func TestMemoryMatchCleansResource(t *testing.T) {
+	escaping := []string{
+		"cortex/agents/alpha/../../secrets/db",
+		"cortex/agents/alpha/../beta/notes",
+		"cortex/agents/alpha/./../../secrets/db",
+	}
 	r := NewMemoryResource("cortex/agents/alpha/*")
-
-	const escaping = "cortex/agents/alpha/../../secrets/db"
-	if !r.MatchResource(escaping) {
-		t.Skip("Match now normalizes the resource; tighten this test to assert that instead")
-	}
-	t.Logf("contract: Match(%q) is true for an unnormalized resource; callers must clean first", escaping)
-
-	// The normalized form of that same string is correctly outside the pattern.
-	if r.MatchResource("cortex/secrets/db") {
-		t.Error("a cleaned resource outside the pattern must not match")
+	for _, resource := range escaping {
+		if r.MatchResource(resource) {
+			t.Errorf("Match(%q) escaped the alpha subtree", resource)
+		}
 	}
 
-	// And a pattern can never carry traversal in the first place.
+	// Cleaning must not break the resources that do belong to it.
+	for _, resource := range []string{
+		"cortex/agents/alpha/notes",
+		"cortex/agents/alpha//notes",
+		"cortex/agents/alpha/seen/workspace",
+	} {
+		if !r.MatchResource(resource) {
+			t.Errorf("Match(%q) rejected a resource inside the subtree", resource)
+		}
+	}
+
+	// Traversal that resolves into the subtree still matches it.
+	if !r.MatchResource("cortex/agents/beta/../alpha/notes") {
+		t.Error("a path resolving into the subtree must match")
+	}
+
+	// A pattern can never carry traversal in the first place.
 	if NewMemoryResource("cortex/agents/alpha/../../secrets/*").IsValid() {
 		t.Error("a pattern with traversal must be invalid")
+	}
+}
+
+// TestBareARNLoadsInsideForeignStatement pins cross-type load compatibility. A
+// bare prefix used to parse as ResourceARNAll, which satisfied every type
+// predicate, so a KMS or Table statement carrying one loaded. It now carries a
+// concrete type, and the type validators tolerate it so those keep loading.
+func TestBareARNLoadsInsideForeignStatement(t *testing.T) {
+	testCases := []struct {
+		name    string
+		policy  string
+		wantErr bool
+	}{
+		{
+			name: "bare S3 prefix in a KMS statement",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow","Action":["kms:ListKeys"],
+				"Resource":["arn:aws:s3:::"]}]}`,
+		},
+		{
+			name: "bare S3 prefix in a Tables statement",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow","Action":["s3tables:GetTableData"],
+				"Resource":["arn:aws:s3:::"]}]}`,
+		},
+		{
+			name: "bare KMS prefix in an S3 statement",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow","Action":["s3:GetObject"],
+				"Resource":["arn:minio:kms:::"]}]}`,
+		},
+		{
+			// Memory statements carry no such tolerance.
+			name: "bare S3 prefix in a Memory statement",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow","Action":["memory:GetAgent"],
+				"Resource":["arn:aws:s3:::"]}]}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var p Policy
+			err := json.Unmarshal([]byte(tc.policy), &p)
+			if err == nil {
+				err = p.Validate()
+			}
+			if tc.wantErr && err == nil {
+				t.Error("expected an error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("a statement already on disk must keep loading, got %v", err)
+			}
+			// Either way it can never be written.
+			if err == nil {
+				if err := p.ValidateStrict(); err == nil {
+					t.Error("ValidateStrict accepted a bare ARN prefix")
+				}
+			}
+		})
 	}
 }
 
@@ -477,6 +548,13 @@ func TestMemoryPolicyValidation(t *testing.T) {
 				"Resource":["arn:minio:memory:::cortex/agents/*"]}]}`,
 		},
 		{
+			name: "valid Memory NotResource",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["memory:GetAgent"],
+				"NotResource":["arn:minio:memory:::cortex/secrets/*"]}]}`,
+		},
+		{
 			name: "NotResource is validated too",
 			policy: `{"Version":"2012-10-17","Statement":[{
 				"Effect":"Allow",
@@ -542,23 +620,25 @@ func TestMemoryPolicyValidation(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		var p Policy
-		err := json.Unmarshal([]byte(tc.policy), &p)
-		if err == nil {
-			err = p.Validate()
-		}
-		if tc.wantErr && err == nil {
-			t.Errorf("%s: expected an error, got nil", tc.name)
-		}
-		if !tc.wantErr && err != nil {
-			t.Errorf("%s: unexpected error %v", tc.name, err)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			var p Policy
+			err := json.Unmarshal([]byte(tc.policy), &p)
+			if err == nil {
+				err = p.Validate()
+			}
+			if tc.wantErr && err == nil {
+				t.Error("expected an error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+		})
 	}
 }
 
 // TestMemoryPolicyIsAllowed drives the evaluation path end to end: a policy
 // scoped to one agent must allow that agent's resources and deny every
-// neighbour, including one whose id shares a prefix.
+// neighbor, including one whose id shares a prefix.
 func TestMemoryPolicyIsAllowed(t *testing.T) {
 	const doc = `{"Version":"2012-10-17","Statement":[{
 		"Effect":"Allow",

--- a/policy/memory-resource_test.go
+++ b/policy/memory-resource_test.go
@@ -1,0 +1,645 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package policy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseMemoryResource(t *testing.T) {
+	testCases := []struct {
+		value       string
+		wantPattern string
+		wantType    ResourceARNType
+	}{
+		{"arn:minio:memory:::cortex", "cortex", ResourceARNMemory},
+		{"arn:minio:memory:::cortex/agents/alpha", "cortex/agents/alpha", ResourceARNMemory},
+		{"arn:minio:memory:::cortex/agents/alpha/*", "cortex/agents/alpha/*", ResourceARNMemory},
+		{"arn:minio:memory:::cortex/secrets/*", "cortex/secrets/*", ResourceARNMemory},
+		{"arn:minio:memory:::*", "*", ResourceARNMemory},
+		{"*", "*", ResourceARNAll},
+	}
+
+	for _, tc := range testCases {
+		got, err := ParseResource(tc.value)
+		if err != nil {
+			t.Errorf("ParseResource(%q): unexpected error %v", tc.value, err)
+			continue
+		}
+		if got.Type != tc.wantType {
+			t.Errorf("ParseResource(%q): type = %v, want %v", tc.value, got.Type, tc.wantType)
+		}
+		if got.Pattern != tc.wantPattern {
+			t.Errorf("ParseResource(%q): pattern = %q, want %q", tc.value, got.Pattern, tc.wantPattern)
+		}
+		if !got.IsValid() {
+			t.Errorf("ParseResource(%q): parsed but not valid", tc.value)
+		}
+	}
+}
+
+// TestMemoryResourceRejected covers the malformed ARNs a policy author or an
+// attacker might write. Each must fail at parse or validation — never parse
+// into something that quietly matches nothing, because a statement that grants
+// less than its author believes is a silent security failure.
+func TestMemoryResourceRejected(t *testing.T) {
+	testCases := []struct {
+		value  string
+		reason string
+	}{
+		// Wrong ARN shape. Two colons puts the cortex in the region field.
+		{"arn:minio:memory:cortex", "cortex in the region field"},
+		{"arn:minio:memory::cortex", "cortex in the account field"},
+		{"arn:minio:memory::::cortex", "extra ARN field"},
+		{"arn:minio:memory", "truncated prefix"},
+		{"arn:minio:memory:::", "prefix with no resource"},
+
+		// Wrong partition or service.
+		{"arn:aws:memory:::cortex", "aws partition"},
+		{"arn:minio:memoryx:::cortex", "service is not memory"},
+		{"arn:minio:mem:::cortex", "abbreviated service"},
+
+		// ARNs are case sensitive.
+		{"ARN:MINIO:MEMORY:::cortex", "upper case prefix"},
+		{"Arn:Minio:Memory:::cortex", "mixed case prefix"},
+
+		// Surrounding or embedded whitespace.
+		{" arn:minio:memory:::cortex", "leading space"},
+		{"arn:minio:memory:::cortex ", "trailing space in pattern"},
+		{"arn:minio:memory:::cor tex", "space inside the cortex"},
+		{"arn:minio:memory:::cortex\t/agents/*", "tab inside the pattern"},
+		{"arn:minio:memory:::cortex\n/agents/*", "newline inside the pattern"},
+
+		// Separator abuse.
+		{"arn:minio:memory::://cortex", "leading separator"},
+		{"arn:minio:memory:::/cortex", "leading separator"},
+		{"arn:minio:memory:::cortex\\agents", "backslash separator"},
+
+		// Traversal segments, which would let a pattern name a resource other
+		// than the one it appears to name.
+		{"arn:minio:memory:::cortex/agents/../secrets/*", "parent segment"},
+		{"arn:minio:memory:::cortex/./agents/*", "current segment"},
+		{"arn:minio:memory:::../cortex/*", "leading parent segment"},
+		{"arn:minio:memory:::cortex/agents/..", "trailing parent segment"},
+
+		// Not an ARN at all.
+		{"", "empty"},
+		{"cortex/agents/alpha", "bare path"},
+		{"memory://cortex/agents/alpha", "url form"},
+	}
+
+	for _, tc := range testCases {
+		r, err := ParseResource(tc.value)
+		if err != nil {
+			continue
+		}
+		if r.IsValid() {
+			t.Errorf("ParseResource(%q) accepted a malformed resource (%s): %#v",
+				tc.value, tc.reason, r)
+			continue
+		}
+		// Parsed but invalid is acceptable only if a statement carrying it is
+		// rejected. Prove that rather than assume it.
+		if err := NewResourceSet(r).ValidateMemory(); err == nil {
+			t.Errorf("ValidateMemory accepted a malformed resource %q (%s)", tc.value, tc.reason)
+		}
+	}
+}
+
+// TestBareARNPrefixIsNotWildcard pins a fix that applies to every ARN type. A
+// bare prefix such as "arn:aws:s3:::" used to parse as ResourceARNAll with its
+// own prefix as the pattern. It therefore validated cleanly and then matched
+// nothing — an Allow that granted zero and, the direction that fails open, a
+// Deny that never fired.
+//
+// It parses as its own type with an empty pattern and is marked bare. AWS
+// rejects the form outright; MinIO keeps it loadable so a policy already on
+// disk keeps working, and refuses it on the create and update paths.
+//
+// Memory ARNs are excluded: see TestBareMemoryARNIsRejected.
+func TestBareARNPrefixIsNotWildcard(t *testing.T) {
+	prefixes := []string{
+		ResourceARNPrefix,
+		ResourceARNS3TablesPrefix,
+		ResourceARNKMSPrefix,
+	}
+
+	for _, prefix := range prefixes {
+		r, err := ParseResource(prefix)
+		if err != nil {
+			t.Errorf("ParseResource(%q): unexpected error %v; it must stay loadable", prefix, err)
+			continue
+		}
+		if r.Type == ResourceARNAll {
+			t.Errorf("ParseResource(%q) = wildcard; a bare prefix names no resource", prefix)
+		}
+		if !r.IsBareARN() {
+			t.Errorf("ParseResource(%q) did not mark the resource bare", prefix)
+		}
+		if r.Pattern != "" {
+			t.Errorf("ParseResource(%q): pattern = %q, want empty", prefix, r.Pattern)
+		}
+
+		// Inert: it matches nothing, which is the behaviour already on disk.
+		for _, probe := range []string{"bucket", "bucket/key", prefix, "*"} {
+			if r.MatchResource(probe) {
+				t.Errorf("bare %q matched %q; it must match nothing", prefix, probe)
+			}
+		}
+
+		// Loadable, but not writable.
+		if err := NewResourceSet(r).ValidateStrict(); err == nil {
+			t.Errorf("ValidateStrict accepted a bare %q", prefix)
+		}
+
+		// It must still round-trip to the string it came from, so re-serializing
+		// a loaded policy does not corrupt it.
+		if got := r.String(); got != prefix {
+			t.Errorf("bare %q round-tripped to %q", prefix, got)
+		}
+	}
+
+	// "*" itself still means every resource.
+	r, err := ParseResource("*")
+	if err != nil || r.Type != ResourceARNAll || !r.IsValid() || r.IsBareARN() {
+		t.Fatalf(`ParseResource("*") = (%#v, %v); want a valid wildcard`, r, err)
+	}
+	if !r.MatchResource("bucket/key") {
+		t.Error(`"*" must match every resource`)
+	}
+	if err := NewResourceSet(r).ValidateStrict(); err != nil {
+		t.Errorf(`ValidateStrict rejected "*": %v`, err)
+	}
+}
+
+// TestBareMemoryARNIsRejected covers the Memory exception to the tolerance in
+// TestBareARNPrefixIsNotWildcard: a bare Memory prefix fails at parse, on both
+// the load and the create paths.
+func TestBareMemoryARNIsRejected(t *testing.T) {
+	if _, err := ParseResource(ResourceARNMemoryPrefix); err == nil {
+		t.Fatalf("ParseResource(%q) accepted a prefix with no resource", ResourceARNMemoryPrefix)
+	}
+
+	const doc = `{"Version":"2012-10-17","Statement":[{
+		"Effect":"Allow",
+		"Action":["memory:GetAgent"],
+		"Resource":["arn:minio:memory:::"]}]}`
+
+	var p Policy
+	if err := json.Unmarshal([]byte(doc), &p); err == nil {
+		if err := p.Validate(); err == nil {
+			t.Error("Validate accepted a bare Memory ARN")
+		}
+	}
+
+	// The wildcard form is the way to name every Memory resource.
+	r, err := ParseResource(ResourceARNMemoryPrefix + "*")
+	if err != nil || !r.IsValid() {
+		t.Fatalf("ParseResource(%q*) = (%#v, %v); want a valid resource", ResourceARNMemoryPrefix, r, err)
+	}
+	if !r.MatchResource("cortex/agents/alpha") {
+		t.Error("the Memory wildcard must match every Memory resource")
+	}
+}
+
+// TestBareARNPolicyLoadsButCannotBeWritten is the compatibility contract for
+// the older ARN types: a stored policy carrying a bare prefix keeps loading,
+// and the same document is refused when someone creates or updates it.
+func TestBareARNPolicyLoadsButCannotBeWritten(t *testing.T) {
+	const doc = `{"Version":"2012-10-17","Statement":[
+	  {"Effect":"Allow","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::*"]},
+	  {"Effect":"Deny","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::"]}]}`
+
+	var p Policy
+	if err := json.Unmarshal([]byte(doc), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("an existing policy must keep loading, got %v", err)
+	}
+	if err := p.ValidateStrict(); err == nil {
+		t.Fatal("ValidateStrict accepted a policy carrying a bare ARN prefix")
+	}
+
+	// The inert Deny still does not fire — unchanged from before the fix, and
+	// the reason writing a new one is now refused.
+	if !p.IsAllowed(Args{
+		AccountName: "u",
+		Action:      "s3:GetObject",
+		BucketName:  "secret",
+		ObjectName:  "data",
+	}) {
+		t.Error("behaviour of an already-stored policy changed")
+	}
+}
+
+func TestMemoryResourceRoundTrip(t *testing.T) {
+	const arn = "arn:minio:memory:::cortex/agents/alpha/*"
+
+	r := NewMemoryResource("cortex/agents/alpha/*")
+	if r.String() != arn {
+		t.Fatalf("String() = %q, want %q", r.String(), arn)
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var back Resource
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back != r {
+		t.Fatalf("round trip changed the resource: got %#v, want %#v", back, r)
+	}
+
+	// A malformed ARN must not survive an unmarshal either.
+	if err := json.Unmarshal([]byte(`"arn:minio:memory:::cortex/../x"`), &back); err == nil {
+		if err := back.Validate(); err == nil {
+			t.Fatal("unmarshal accepted a traversal pattern")
+		}
+	}
+}
+
+// TestParseResourceIsDeterministic guards against the map iteration in
+// ParseResource. The ARN prefixes do not currently overlap, so the result must
+// not depend on iteration order; if a future prefix does overlap, this fails
+// loudly instead of producing a policy that means different things per process.
+func TestParseResourceIsDeterministic(t *testing.T) {
+	inputs := []string{
+		"arn:aws:s3:::bucket/*",
+		"arn:aws:s3tables:::bucket/wh/table/id",
+		"arn:minio:kms:::key",
+		"arn:minio:memory:::cortex/agents/alpha/*",
+		"*",
+	}
+	for _, in := range inputs {
+		first, err := ParseResource(in)
+		if err != nil {
+			t.Fatalf("ParseResource(%q): %v", in, err)
+		}
+		for range 200 {
+			got, err := ParseResource(in)
+			if err != nil || got != first {
+				t.Fatalf("ParseResource(%q) is not deterministic: got (%#v, %v), want %#v",
+					in, got, err, first)
+			}
+		}
+	}
+}
+
+func TestMemoryResourceIsValid(t *testing.T) {
+	testCases := []struct {
+		pattern string
+		want    bool
+	}{
+		{"cortex", true},
+		{"cortex/agents/alpha", true},
+		{"cortex/agents/alpha/*", true},
+		{"cortex/*", true},
+		{"*", true},
+		{"cortex/agents/alpha..beta", true}, // dots inside a segment are fine
+		{"", false},
+		{"/cortex", false},
+		{"cortex/../secrets", false},
+		{"cortex/./agents", false},
+		{"..", false},
+		{"cortex:extra", false},
+		{"cortex agents", false},
+		{"cortex\\agents", false},
+	}
+
+	for _, tc := range testCases {
+		if got := NewMemoryResource(tc.pattern).IsValid(); got != tc.want {
+			t.Errorf("IsValid(%q) = %v, want %v", tc.pattern, got, tc.want)
+		}
+	}
+}
+
+// TestMemoryResourceMatch pins the subtree idiom. A pattern ending in "/*"
+// does not match the parent itself, so granting an agent both its record and
+// everything beneath it takes two resources — the same shape S3 already
+// requires for a bucket and its objects.
+func TestMemoryResourceMatch(t *testing.T) {
+	testCases := []struct {
+		pattern  string
+		resource string
+		want     bool
+	}{
+		// Subtree pattern covers descendants but not the record itself.
+		{"cortex/agents/alpha/*", "cortex/agents/alpha/notes", true},
+		{"cortex/agents/alpha/*", "cortex/agents/alpha", false},
+
+		// Which is why the record needs its own exact resource.
+		{"cortex/agents/alpha", "cortex/agents/alpha", true},
+		{"cortex/agents/alpha", "cortex/agents/alpha/notes", false},
+
+		// A prefix wildcard leaks across agents. Documented so nobody reaches
+		// for it as a shorthand for the two-resource idiom.
+		{"cortex/agents/alpha*", "cortex/agents/alpha2", true},
+		{"cortex/agents/alpha*", "cortex/agents/alphabet/notes", true},
+
+		// Collection and cortex wildcards.
+		{"cortex/agents/*", "cortex/agents/alpha", true},
+		{"cortex/secrets/*", "cortex/secrets/db/prod", true},
+		{"cortex/secrets/*", "cortex/agents/alpha", false},
+		{"cortex/*", "cortex/agents/alpha", true},
+		{"cortex", "cortex", true},
+		{"cortex", "other", false},
+
+		// "*" crosses separators, matching S3 semantics. A pattern cannot
+		// constrain a single path segment.
+		{"cortex/agents/*/notes", "cortex/agents/alpha/beta/notes", true},
+
+		// Cortex boundaries hold.
+		{"cortex/agents/*", "other/agents/alpha", false},
+		{"cortex/agents/alpha/*", "cortexevil/agents/alpha/notes", false},
+		{"cortex", "cortex2", false},
+		{"*", "cortex/agents/alpha", true},
+	}
+
+	for _, tc := range testCases {
+		r := NewMemoryResource(tc.pattern)
+		if got := r.MatchResource(tc.resource); got != tc.want {
+			t.Errorf("Match(pattern=%q, resource=%q) = %v, want %v",
+				tc.pattern, tc.resource, got, tc.want)
+		}
+	}
+}
+
+// TestMemoryMatchRequiresCleanResource documents a caller contract that is
+// security relevant. Match compares a cleaned resource only on the exact-match
+// fast path; the wildcard fallback sees the raw string. So a resource carrying
+// traversal segments matches a subtree pattern it does not logically belong
+// to. Callers must pass an already-normalized resource path.
+//
+// Patterns cannot carry traversal — IsValid rejects that — so this is purely a
+// constraint on what the server computes from a request.
+func TestMemoryMatchRequiresCleanResource(t *testing.T) {
+	r := NewMemoryResource("cortex/agents/alpha/*")
+
+	const escaping = "cortex/agents/alpha/../../secrets/db"
+	if !r.MatchResource(escaping) {
+		t.Skip("Match now normalizes the resource; tighten this test to assert that instead")
+	}
+	t.Logf("contract: Match(%q) is true for an unnormalized resource; callers must clean first", escaping)
+
+	// The normalized form of that same string is correctly outside the pattern.
+	if r.MatchResource("cortex/secrets/db") {
+		t.Error("a cleaned resource outside the pattern must not match")
+	}
+
+	// And a pattern can never carry traversal in the first place.
+	if NewMemoryResource("cortex/agents/alpha/../../secrets/*").IsValid() {
+		t.Error("a pattern with traversal must be invalid")
+	}
+}
+
+// TestMemoryResourceTypeIsolation proves a Memory grant cannot be written as,
+// or satisfied by, any other resource type. Each validator must reject the
+// others, so no policy can express Memory access through an S3 ARN or the
+// reverse.
+func TestMemoryResourceTypeIsolation(t *testing.T) {
+	memory := NewResourceSet(NewMemoryResource("cortex/agents/alpha/*"))
+	s3 := NewResourceSet(NewResource("cortex/*"))
+	kms := NewResourceSet(NewKMSResource("key"))
+	tables := NewResourceSet(NewS3TablesResource("bucket/wh/table/id"))
+
+	if err := memory.ValidateS3(); err == nil {
+		t.Error("ValidateS3 accepted a Memory ARN")
+	}
+	if err := memory.ValidateKMS(); err == nil {
+		t.Error("ValidateKMS accepted a Memory ARN")
+	}
+	if err := memory.ValidateTable(); err == nil {
+		t.Error("ValidateTable accepted a Memory ARN")
+	}
+	if err := s3.ValidateMemory(); err == nil {
+		t.Error("ValidateMemory accepted an S3 ARN")
+	}
+	if err := kms.ValidateMemory(); err == nil {
+		t.Error("ValidateMemory accepted a KMS ARN")
+	}
+	if err := tables.ValidateMemory(); err == nil {
+		t.Error("ValidateMemory accepted an S3 Tables ARN")
+	}
+	if err := memory.ValidateMemory(); err != nil {
+		t.Errorf("ValidateMemory rejected a Memory ARN: %v", err)
+	}
+}
+
+// TestMemoryPolicyValidation exercises whole policy documents, which is the
+// path a real deployment takes.
+func TestMemoryPolicyValidation(t *testing.T) {
+	testCases := []struct {
+		name    string
+		policy  string
+		wantErr bool
+	}{
+		{
+			name: "agent record and its subtree",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["memory:GetAgent","memory:PutAgent"],
+				"Resource":["arn:minio:memory:::cortex/agents/alpha",
+				            "arn:minio:memory:::cortex/agents/alpha/*"]}]}`,
+		},
+		{
+			name: "cortex-wide list",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["memory:ListAgents"],
+				"Resource":["arn:minio:memory:::cortex/*"]}]}`,
+		},
+		{
+			name: "deny statement",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Deny",
+				"Action":["memory:DeleteAgent"],
+				"Resource":["arn:minio:memory:::cortex/agents/*"]}]}`,
+		},
+		{
+			name: "NotResource is validated too",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["memory:GetAgent"],
+				"NotResource":["arn:aws:s3:::cortex/*"]}]}`,
+			wantErr: true,
+		},
+		{
+			name: "S3 ARN cannot carry a Memory action",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["memory:GetAgent"],
+				"Resource":["arn:aws:s3:::cortex/*"]}]}`,
+			wantErr: true,
+		},
+		{
+			name: "Memory ARN cannot carry an S3 action",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["s3:GetObject"],
+				"Resource":["arn:minio:memory:::cortex/agents/alpha"]}]}`,
+			wantErr: true,
+		},
+		{
+			name: "action types cannot be mixed",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["memory:GetAgent","s3:GetObject"],
+				"Resource":["arn:minio:memory:::cortex/agents/alpha"]}]}`,
+			wantErr: true,
+		},
+		{
+			name: "resource is required",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["memory:GetAgent"]}]}`,
+			wantErr: true,
+		},
+		{
+			name: "traversal in a resource is rejected",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["memory:GetAgent"],
+				"Resource":["arn:minio:memory:::cortex/agents/../secrets/*"]}]}`,
+			wantErr: true,
+		},
+		{
+			name: "bare prefix is rejected",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["memory:GetAgent"],
+				"Resource":["arn:minio:memory:::"]}]}`,
+			wantErr: true,
+		},
+		{
+			name: "unknown memory action is rejected",
+			policy: `{"Version":"2012-10-17","Statement":[{
+				"Effect":"Allow",
+				"Action":["memory:StealAgent"],
+				"Resource":["arn:minio:memory:::cortex/agents/alpha"]}]}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		var p Policy
+		err := json.Unmarshal([]byte(tc.policy), &p)
+		if err == nil {
+			err = p.Validate()
+		}
+		if tc.wantErr && err == nil {
+			t.Errorf("%s: expected an error, got nil", tc.name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("%s: unexpected error %v", tc.name, err)
+		}
+	}
+}
+
+// TestMemoryPolicyIsAllowed drives the evaluation path end to end: a policy
+// scoped to one agent must allow that agent's resources and deny every
+// neighbour, including one whose id shares a prefix.
+func TestMemoryPolicyIsAllowed(t *testing.T) {
+	const doc = `{"Version":"2012-10-17","Statement":[{
+		"Effect":"Allow",
+		"Action":["memory:GetAgent"],
+		"Resource":["arn:minio:memory:::cortex/agents/alpha",
+		            "arn:minio:memory:::cortex/agents/alpha/*"]}]}`
+
+	var p Policy
+	if err := json.Unmarshal([]byte(doc), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	testCases := []struct {
+		object string
+		want   bool
+	}{
+		{"agents/alpha", true},
+		{"agents/alpha/notes", true},
+		{"agents/alpha/seen/workspace", true},
+		{"agents/alpha2", false},
+		{"agents/alphabet", false},
+		{"agents/beta", false},
+		{"secrets/db", false},
+		{"", false},
+	}
+
+	for _, tc := range testCases {
+		got := p.IsAllowed(Args{
+			AccountName: "tester",
+			Action:      Action(MemoryGetAgentAction),
+			BucketName:  "cortex",
+			ObjectName:  tc.object,
+		})
+		if got != tc.want {
+			t.Errorf("IsAllowed(cortex/%s) = %v, want %v", tc.object, got, tc.want)
+		}
+	}
+
+	// A different cortex is never reachable, whatever the object.
+	if p.IsAllowed(Args{
+		AccountName: "tester",
+		Action:      Action(MemoryGetAgentAction),
+		BucketName:  "other",
+		ObjectName:  "agents/alpha",
+	}) {
+		t.Error("a policy scoped to one cortex allowed another")
+	}
+
+	// A different action is never reachable, whatever the resource.
+	if p.IsAllowed(Args{
+		AccountName: "tester",
+		Action:      Action(MemoryDeleteAgentAction),
+		BucketName:  "cortex",
+		ObjectName:  "agents/alpha",
+	}) {
+		t.Error("a policy granting GetAgent allowed DeleteAgent")
+	}
+}
+
+// TestMemoryResourceStringNeverLeaksStorage is a guard on the whole point of
+// the Memory ARN: it names a logical resource, so no storage detail may appear
+// in a policy document. If the storage layout ever leaks into an ARN, every
+// policy becomes coupled to it.
+func TestMemoryResourceStringNeverLeaksStorage(t *testing.T) {
+	for _, pattern := range []string{
+		"cortex",
+		"cortex/agents/alpha",
+		"cortex/agents/alpha/*",
+		"cortex/secrets/db/prod",
+	} {
+		got := NewMemoryResource(pattern).String()
+		for _, leak := range []string{".mem", ".secrets", ".cortex", "profile.json", "/L0/", "/L1/"} {
+			if strings.Contains(got, leak) {
+				t.Errorf("Memory ARN %q leaks storage detail %q", got, leak)
+			}
+		}
+		if !strings.HasPrefix(got, ResourceARNMemoryPrefix) {
+			t.Errorf("Memory ARN %q lost its prefix", got)
+		}
+	}
+}

--- a/policy/resource.go
+++ b/policy/resource.go
@@ -37,21 +37,10 @@ const (
 	// ResourceARNKMSPrefix is for KMS key resources. MinIO specific API.
 	ResourceARNKMSPrefix = "arn:minio:kms:::"
 
-	// ResourceARNMemoryPrefix is for AIStor Memory API resources. MinIO
-	// specific API; AWS has no equivalent service to borrow an ARN from.
-	//
-	// The pattern is the logical Memory path — <cortex>, <cortex>/secrets/<name>,
-	// <cortex>/agents/<id> — never a storage key, so the Memory API's on-disk
-	// layout can change without invalidating a policy.
-	//
-	// Granting an agent both its record and everything beneath it takes two
-	// resources, because a "/*" pattern does not match its own parent:
-	//
-	//	arn:minio:memory:::cortex/agents/alpha
-	//	arn:minio:memory:::cortex/agents/alpha/*
-	//
-	// This is the shape S3 already requires for a bucket and its objects.
-	// Collapsing it to "alpha*" would also match an unrelated agent "alpha2".
+	// ResourceARNMemoryPrefix is for AIStor Memory API resources. MinIO specific
+	// API. The pattern is the logical Memory path — <cortex>/agents/<id> — never
+	// a storage key. A "/*" pattern does not match its own parent, so covering a
+	// record and its subtree takes two resources, as it does for S3.
 	ResourceARNMemoryPrefix = "arn:minio:memory:::"
 )
 
@@ -106,22 +95,15 @@ type Resource struct {
 	Pattern string
 	Type    ResourceARNType
 
-	// bareARN marks a resource that named an ARN prefix with nothing after it,
-	// such as "arn:aws:s3:::". It names no resource, so it matches nothing: an
-	// Allow grants nothing and a Deny never fires, which is the direction that
-	// fails open.
-	//
-	// Such a resource loads but cannot be written: isValid accepts it so a
-	// policy already on disk keeps working, and ValidateStrict refuses it on
-	// the create and update paths.
-	//
-	// Only the S3, S3 Tables and KMS ARNs carry this tolerance. A bare Memory
-	// ARN is an error at parse.
+	// bareARN marks an ARN prefix with nothing after it, such as "arn:aws:s3:::".
+	// It names no resource and matches nothing, so a Deny written that way never
+	// fires. It loads but cannot be written: isValid accepts it, ValidateStrict
+	// refuses it. Memory ARNs are an error at parse instead.
 	bareARN bool
 }
 
-// IsBareARN reports whether the resource named an ARN prefix with no resource
-// after it. Such a resource is inert: it matches nothing.
+// IsBareARN reports whether the resource is an ARN prefix naming no resource.
+// Such a resource is inert: it matches nothing.
 func (r Resource) IsBareARN() bool { return r.bareARN }
 
 func (r Resource) isKMS() bool {
@@ -185,16 +167,9 @@ func (r Resource) IsValid() bool {
 }
 
 // isValidMemoryPattern reports whether pattern can name a Memory resource.
-//
 // A Memory pattern is <cortex>[/<collection>[/<name>]], where <cortex> is a
-// bucket name. Anything a bucket name cannot contain is rejected here rather
-// than accepted as a pattern that silently matches nothing — a policy that
-// grants less than its author believes is worse than one that fails to load.
-//
-// Rejected: a leading separator (the cortex would be empty), a colon (an extra
-// ARN field leaked into the resource), whitespace, a backslash, and any "."
-// or ".." path segment (which would let a pattern name a resource other than
-// the one it appears to name).
+// bucket name. Rejects a leading separator, a colon, whitespace, a backslash,
+// and any "." or ".." segment.
 func isValidMemoryPattern(pattern string) bool {
 	if pattern == "" || strings.HasPrefix(pattern, "/") {
 		return false
@@ -216,7 +191,15 @@ func (r Resource) MatchResource(resource string) bool {
 }
 
 // Match - matches object name with resource pattern, including specific conditionals.
+//
+// A Memory resource names a logical path, so the candidate is cleaned before
+// matching. Other ARN types match verbatim: callers must pass a cleaned path.
 func (r Resource) Match(resource string, conditionValues map[string][]string) bool {
+	if r.Type == ResourceARNMemory {
+		if cleaned := path.Clean(resource); cleaned != "." {
+			resource = cleaned
+		}
+	}
 	// Happy path, with no replacements
 	idx := strings.IndexByte(r.Pattern, '$')
 	if idx < 0 {
@@ -333,9 +316,8 @@ func (r Resource) ValidateBucket(bucketName string) error {
 
 // ParseResource - parses string to Resource.
 func ParseResource(s string) (Resource, error) {
-	// "*" is the only string that denotes every resource. A bare ARN prefix
-	// such as "arn:aws:s3:::" names no resource and is not a wildcard; it
-	// parses as its own type with an empty pattern and is marked bareARN.
+	// "*" is the only string denoting every resource. A bare ARN prefix names
+	// none, and parses as its own type with an empty pattern.
 	if s == ResourceARNAll.String() {
 		return Resource{Type: ResourceARNAll, Pattern: s}, nil
 	}

--- a/policy/resource.go
+++ b/policy/resource.go
@@ -36,6 +36,23 @@ const (
 
 	// ResourceARNKMSPrefix is for KMS key resources. MinIO specific API.
 	ResourceARNKMSPrefix = "arn:minio:kms:::"
+
+	// ResourceARNMemoryPrefix is for AIStor Memory API resources. MinIO
+	// specific API; AWS has no equivalent service to borrow an ARN from.
+	//
+	// The pattern is the logical Memory path — <cortex>, <cortex>/secrets/<name>,
+	// <cortex>/agents/<id> — never a storage key, so the Memory API's on-disk
+	// layout can change without invalidating a policy.
+	//
+	// Granting an agent both its record and everything beneath it takes two
+	// resources, because a "/*" pattern does not match its own parent:
+	//
+	//	arn:minio:memory:::cortex/agents/alpha
+	//	arn:minio:memory:::cortex/agents/alpha/*
+	//
+	// This is the shape S3 already requires for a bucket and its objects.
+	// Collapsing it to "alpha*" would also match an unrelated agent "alpha2".
+	ResourceARNMemoryPrefix = "arn:minio:memory:::"
 )
 
 // ResourceARNType - ARN prefix type
@@ -54,6 +71,9 @@ const (
 	// ResourceARNKMS is the ARN prefix type for MinIO KMS resources.
 	ResourceARNKMS
 
+	// ResourceARNMemory is the ARN prefix type for AIStor Memory resources.
+	ResourceARNMemory
+
 	// ResourceARNAll is the ARN '*'
 	ResourceARNAll
 )
@@ -63,6 +83,7 @@ var ARNTypeToPrefix = map[ResourceARNType]string{
 	ResourceARNS3:       ResourceARNPrefix,
 	ResourceARNS3Tables: ResourceARNS3TablesPrefix,
 	ResourceARNKMS:      ResourceARNKMSPrefix,
+	ResourceARNMemory:   ResourceARNMemoryPrefix,
 	ResourceARNAll:      "*",
 }
 
@@ -84,7 +105,24 @@ func (a ResourceARNType) String() string {
 type Resource struct {
 	Pattern string
 	Type    ResourceARNType
+
+	// bareARN marks a resource that named an ARN prefix with nothing after it,
+	// such as "arn:aws:s3:::". It names no resource, so it matches nothing: an
+	// Allow grants nothing and a Deny never fires, which is the direction that
+	// fails open.
+	//
+	// Such a resource loads but cannot be written: isValid accepts it so a
+	// policy already on disk keeps working, and ValidateStrict refuses it on
+	// the create and update paths.
+	//
+	// Only the S3, S3 Tables and KMS ARNs carry this tolerance. A bare Memory
+	// ARN is an error at parse.
+	bareARN bool
 }
+
+// IsBareARN reports whether the resource named an ARN prefix with no resource
+// after it. Such a resource is inert: it matches nothing.
+func (r Resource) IsBareARN() bool { return r.bareARN }
 
 func (r Resource) isKMS() bool {
 	return r.Type == ResourceARNKMS || r.Type == ResourceARNAll
@@ -96,6 +134,10 @@ func (r Resource) isS3() bool {
 
 func (r Resource) isTable() bool {
 	return r.Type == ResourceARNS3Tables || r.Type == ResourceARNAll
+}
+
+func (r Resource) isMemory() bool {
+	return r.Type == ResourceARNMemory || r.Type == ResourceARNAll
 }
 
 func (r Resource) isBucketPattern() bool {
@@ -111,6 +153,11 @@ func (r Resource) IsValid() bool {
 	if r.Type == unknownARN {
 		return false
 	}
+	// A bare ARN prefix is tolerated here so existing policies keep loading.
+	// It is inert, and ValidateStrict refuses to let a new one be written.
+	if r.bareARN {
+		return true
+	}
 	if r.isS3() {
 		if strings.HasPrefix(r.Pattern, "/") {
 			return false
@@ -118,6 +165,11 @@ func (r Resource) IsValid() bool {
 	}
 	if r.isTable() {
 		if strings.HasPrefix(r.Pattern, "/") {
+			return false
+		}
+	}
+	if r.Type == ResourceARNMemory {
+		if !isValidMemoryPattern(r.Pattern) {
 			return false
 		}
 	}
@@ -130,6 +182,32 @@ func (r Resource) IsValid() bool {
 	}
 
 	return r.Pattern != ""
+}
+
+// isValidMemoryPattern reports whether pattern can name a Memory resource.
+//
+// A Memory pattern is <cortex>[/<collection>[/<name>]], where <cortex> is a
+// bucket name. Anything a bucket name cannot contain is rejected here rather
+// than accepted as a pattern that silently matches nothing — a policy that
+// grants less than its author believes is worse than one that fails to load.
+//
+// Rejected: a leading separator (the cortex would be empty), a colon (an extra
+// ARN field leaked into the resource), whitespace, a backslash, and any "."
+// or ".." path segment (which would let a pattern name a resource other than
+// the one it appears to name).
+func isValidMemoryPattern(pattern string) bool {
+	if pattern == "" || strings.HasPrefix(pattern, "/") {
+		return false
+	}
+	if strings.ContainsAny(pattern, ":\\ \t\r\n") {
+		return false
+	}
+	for _, segment := range strings.Split(pattern, "/") {
+		if segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
 }
 
 // MatchResource matches object name with resource pattern only.
@@ -255,12 +333,16 @@ func (r Resource) ValidateBucket(bucketName string) error {
 
 // ParseResource - parses string to Resource.
 func ParseResource(s string) (Resource, error) {
+	// "*" is the only string that denotes every resource. A bare ARN prefix
+	// such as "arn:aws:s3:::" names no resource and is not a wildcard; it
+	// parses as its own type with an empty pattern and is marked bareARN.
+	if s == ResourceARNAll.String() {
+		return Resource{Type: ResourceARNAll, Pattern: s}, nil
+	}
+
 	r := Resource{}
 	for k, v := range ARNPrefixToType {
-		if s == k {
-			// all pattern
-			r.Type = ResourceARNAll
-			r.Pattern = k
+		if k == ResourceARNAll.String() {
 			continue
 		}
 		if rem, ok := strings.CutPrefix(s, k); ok {
@@ -271,6 +353,16 @@ func ParseResource(s string) (Resource, error) {
 	}
 	if r.Type == unknownARN {
 		return r, Errorf("invalid resource '%v'", s)
+	}
+
+	if r.Pattern == "" {
+		// Memory ARNs carry no compatibility tolerance.
+		if r.Type == ResourceARNMemory {
+			return r, Errorf("invalid resource '%v' - an ARN prefix with no resource after it matches nothing; use '%v*' to mean every Memory resource",
+				s, ResourceARNMemoryPrefix)
+		}
+		r.bareARN = true
+		return r, nil
 	}
 
 	if strings.HasPrefix(r.Pattern, "/") {
@@ -293,6 +385,16 @@ func NewKMSResource(pattern string) Resource {
 	return Resource{
 		Pattern: pattern,
 		Type:    ResourceARNKMS,
+	}
+}
+
+// NewMemoryResource - creates new resource with type Memory. The pattern is
+// the logical Memory path, <cortex>[/<collection>[/<name>]] — never a storage
+// key, so the Memory API's on-disk layout stays out of policy documents.
+func NewMemoryResource(pattern string) Resource {
+	return Resource{
+		Pattern: pattern,
+		Type:    ResourceARNMemory,
 	}
 }
 

--- a/policy/resourceset.go
+++ b/policy/resourceset.go
@@ -150,6 +150,21 @@ func (resourceSet *ResourceSet) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// ValidateStrict rejects resources that Validate tolerates only for backward
+// compatibility. Servers call this when creating or updating a policy, so a
+// construct that already exists on disk keeps loading while no new one can be
+// written.
+func (resourceSet ResourceSet) ValidateStrict() error {
+	for resource := range resourceSet {
+		if resource.IsBareARN() {
+			return Errorf("invalid resource '%v' - an ARN prefix with no resource after it matches nothing; use '%v*' to mean every resource",
+				resource, resource.Type)
+		}
+	}
+
+	return nil
+}
+
 // ValidateS3 - validates ResourceSet is S3.
 func (resourceSet ResourceSet) ValidateS3() error {
 	for resource := range resourceSet {
@@ -208,12 +223,15 @@ func (resourceSet ResourceSet) ValidateVectors() error {
 }
 
 // ValidateMemory - validates ResourceSet for the AIStor Memory API.
-// A Memory cortex is an S3 bucket, so resources use S3 ARN format
-// (e.g., arn:aws:s3:::my-cortex or arn:aws:s3:::my-cortex/*).
+// Memory resources use their own ARN namespace (e.g.
+// arn:minio:memory:::my-cortex/agents/alpha/*) rather than the S3 ARN of the
+// bucket backing the cortex. The two are deliberately separate: a Memory ARN
+// names a logical resource, so it stays valid when the storage layout changes,
+// and granting Memory access never implies raw S3 access to the same bytes.
 func (resourceSet ResourceSet) ValidateMemory() error {
 	for resource := range resourceSet {
-		if !resource.isS3() {
-			return Errorf("resource '%v' type is not S3", resource)
+		if !resource.isMemory() {
+			return Errorf("resource '%v' type is not Memory", resource)
 		}
 		if err := resource.Validate(); err != nil {
 			return err

--- a/policy/resourceset.go
+++ b/policy/resourceset.go
@@ -150,10 +150,8 @@ func (resourceSet *ResourceSet) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// ValidateStrict rejects resources that Validate tolerates only for backward
-// compatibility. Servers call this when creating or updating a policy, so a
-// construct that already exists on disk keeps loading while no new one can be
-// written.
+// ValidateStrict rejects resources that Validate tolerates for backward
+// compatibility. Servers call it when creating or updating a policy.
 func (resourceSet ResourceSet) ValidateStrict() error {
 	for resource := range resourceSet {
 		if resource.IsBareARN() {
@@ -168,7 +166,7 @@ func (resourceSet ResourceSet) ValidateStrict() error {
 // ValidateS3 - validates ResourceSet is S3.
 func (resourceSet ResourceSet) ValidateS3() error {
 	for resource := range resourceSet {
-		if !resource.isS3() {
+		if !resource.IsBareARN() && !resource.isS3() {
 			return Errorf("resource '%v' type is not S3", resource)
 		}
 		if err := resource.Validate(); err != nil {
@@ -182,7 +180,7 @@ func (resourceSet ResourceSet) ValidateS3() error {
 // ValidateKMS - validates ResourceSet is KMS.
 func (resourceSet ResourceSet) ValidateKMS() error {
 	for resource := range resourceSet {
-		if !resource.isKMS() {
+		if !resource.IsBareARN() && !resource.isKMS() {
 			return Errorf("resource '%v' type is not KMS", resource)
 		}
 		if err := resource.Validate(); err != nil {
@@ -196,7 +194,7 @@ func (resourceSet ResourceSet) ValidateKMS() error {
 // ValidateTable - validates ResourceSet is S3 Tables.
 func (resourceSet ResourceSet) ValidateTable() error {
 	for resource := range resourceSet {
-		if !resource.isTable() {
+		if !resource.IsBareARN() && !resource.isTable() {
 			return Errorf("resource '%v' type is not S3 Tables", resource)
 		}
 		if err := resource.Validate(); err != nil {
@@ -211,7 +209,7 @@ func (resourceSet ResourceSet) ValidateTable() error {
 // S3 Vectors uses S3 ARN format for resources (e.g., arn:aws:s3:::vectors-bucket/*).
 func (resourceSet ResourceSet) ValidateVectors() error {
 	for resource := range resourceSet {
-		if !resource.isS3() {
+		if !resource.IsBareARN() && !resource.isS3() {
 			return Errorf("resource '%v' type is not S3", resource)
 		}
 		if err := resource.Validate(); err != nil {
@@ -228,6 +226,8 @@ func (resourceSet ResourceSet) ValidateVectors() error {
 // bucket backing the cortex. The two are deliberately separate: a Memory ARN
 // names a logical resource, so it stays valid when the storage layout changes,
 // and granting Memory access never implies raw S3 access to the same bytes.
+//
+// Unlike the other type validators, this one does not tolerate a bare ARN.
 func (resourceSet ResourceSet) ValidateMemory() error {
 	for resource := range resourceSet {
 		if !resource.isMemory() {

--- a/policy/statement.go
+++ b/policy/statement.go
@@ -475,6 +475,17 @@ func (statement Statement) isValidStrict() error {
 		return err
 	}
 
+	// Applies to every action type: a bare ARN prefix names no resource, so a
+	// statement carrying one is inert — an Allow grants nothing and a Deny
+	// never fires. Existing policies keep loading through isValid; a new one
+	// must not be written.
+	if err := statement.Resources.ValidateStrict(); err != nil {
+		return err
+	}
+	if err := statement.NotResources.ValidateStrict(); err != nil {
+		return err
+	}
+
 	if statement.isAdmin() {
 		return statement.validateAdmin(true)
 	}


### PR DESCRIPTION
## What

Memory resources get their own ARN namespace:

```
arn:minio:memory:::<cortex>[/<collection>[/<name>]]
```

They were authorized against the S3 ARN of the bucket backing the cortex, which
forced the storage path into every policy and made a Memory grant
indistinguishable from raw S3 access to the same bytes. The pattern is now a
logical path, so the Memory API's on-disk layout can change without
invalidating a policy.

`ValidateMemory` requires the Memory type, so an S3 ARN cannot carry a Memory
action and a Memory ARN cannot carry an S3 one.

## Bare ARN prefix fix (affects every ARN type)

`arn:aws:s3:::` parsed as `ResourceARNAll` keeping its own prefix as the
pattern. It validated cleanly and then matched nothing — an `Allow` that
granted zero and, the direction that fails open, a `Deny` that never fired:

```
ParseResource("arn:aws:s3:::") -> Type=* Pattern="arn:aws:s3:::"
    matches "mybucket/key"? false
policy validates: <nil>
GetObject allowed despite the Deny? true
```

AWS rejects the form outright. It now parses as its own type with an empty
pattern. S3, S3 Tables and KMS keep loading one so a policy already on disk
still works, with `ValidateStrict` refusing it on create/update — the split
`ParseConfigStrict` already exists to provide. Memory carries no such
tolerance and fails at parse.

## Tests

Memory resources had no coverage; the suite passed because nothing exercised
them. Adds parsing, validation, matching, cross-type isolation, whole-document
validation and end-to-end evaluation — including that an agent-scoped grant
denies a neighbour whose id shares a prefix, and that a bare-prefix policy
loads but cannot be written.

Both defences mutation-checked: dropping traversal/charset rejection fails 17
assertions; letting Memory inherit the bare-ARN tolerance fails 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for AIStor Memory resources in policy ARNs.
  - Added Memory resource validation and wildcard matching.
  - Added strict policy validation that rejects incomplete resource prefixes and accepts explicit wildcard forms.
  - Added safeguards for resource type and scope isolation.

- **Bug Fixes**
  - Prevented malformed or traversal-based Memory resources from being accepted.
  - Ensured resource representations do not expose underlying storage details.
  - Preserved compatibility when loading existing bare ARN policies while preventing unsafe updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->