### PR TITLE
docs(policy): correct the AWS justification for the bare-ARN fix

### DIFF
--- a/policy/memory-resource_test.go
+++ b/policy/memory-resource_test.go
@@ -130,8 +130,11 @@ func TestMemoryResourceRejected(t *testing.T) {
 // Deny that never fired.
 //
 // It parses as its own type with an empty pattern and is marked bare. AWS
-// rejects the form outright; MinIO keeps it loadable so a policy already on
-// disk keeps working, and refuses it on the create and update paths.
+// documents no S3 resource type with an empty bucket name, and its
+// wildcard-completion rule is scoped to ARNs with fewer than six fields, so
+// this six-field form is not equivalent to "*". MinIO keeps it loadable so a
+// policy already on disk keeps working, and refuses it on the create and
+// update paths.
 //
 // Memory ARNs are excluded: see TestBareMemoryARNIsRejected.
 func TestBareARNPrefixIsNotWildcard(t *testing.T) {


### PR DESCRIPTION
Follow-up to #249. Comment-only, no behavior change.

#249 asserted that AWS rejects `arn:aws:s3:::` outright. That is unsupported and
I should not have stated it as fact:

- AWS's [published policy grammar](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html)
  defines `resource_string` as only "In most cases, consists of an ARN" — it
  constrains nothing about ARN internals.
- `moto`, which reimplements AWS's `MalformedPolicyDocument` responses, **accepts**
  `arn:aws:s3:::`. It rejects `arn:aws:s3` and `notanarn`, so it does have a
  resource-ARN rejection path; the empty form passes through it.
- `parliament` and `policy_sentry`, run offline, both parse it as structurally valid.

What does hold:

- AWS documents no S3 resource type with an empty bucket name — the bucket ARN is
  `arn:${Partition}:s3:::${BucketName}`, and the documented "all buckets and
  objects" form is [`arn:aws:s3:::*`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-arn-format.html).
- AWS's wildcard-completion rule — which fills missing fields with `*` — is
  explicitly scoped to ARNs with *fewer than the standard six fields*.
  `arn:aws:s3:::` has six, so that rule does not make it equivalent to `*`.

Worth stating plainly for anyone re-checking: `*` legally expands to zero
characters, so one can argue `arn:aws:s3:::` and `arn:aws:s3:::*` differ only by
a zero-width wildcard. The field-count argument above is what separates them.

The fix in #249 is unaffected — it rests on MinIO's own behavior, where a bare
prefix matched nothing and a `Deny` written that way never fired.

There is no tool that can police this in CI: Access Analyzer has no offline mode
and needs credentials, and `parliament` — the credential-free option — does not
flag this case, so wiring it in would quietly contradict the claim rather than
verify it.