### PR TITLE
fix(policy): restore parsing of star-prefixed resources

### DIFF
--- a/policy/condition/keyname.go
+++ b/policy/condition/keyname.go
@@ -129,6 +129,18 @@ const (
 	// S3Delimiter - key representing delimiter query parameter of ListBucket API only.
 	S3Delimiter KeyName = "s3:delimiter"
 
+	// MemoryPrefix - key representing the prefix query parameter of the AIStor
+	// Memory list APIs only. It scopes enumeration within a cortex, which a
+	// resource ARN cannot express: a list names a query, not a record, so
+	// putting the prefix in the resource path would make one ARN mean a single
+	// record under a read action and a set of siblings under a list action.
+	MemoryPrefix KeyName = "memory:prefix"
+
+	// MemoryMaxKeys - key representing the limit query parameter of the AIStor
+	// Memory list APIs only. It caps a single page, bounding what one request
+	// can enumerate.
+	MemoryMaxKeys KeyName = "memory:max-keys"
+
 	// S3VersionID - Enables you to limit the permission for the
 	// s3:PutObjectVersionTagging action to a specific object version.
 	S3VersionID KeyName = "s3:versionid"
@@ -301,6 +313,8 @@ var AllSupportedKeys = []KeyName{
 	S3Prefix,
 	S3Delimiter,
 	S3MaxKeys,
+	MemoryPrefix,
+	MemoryMaxKeys,
 	S3VersionID,
 	S3ObjectLockRemainingRetentionDays,
 	S3ObjectLockMode,

--- a/policy/memory-action.go
+++ b/policy/memory-action.go
@@ -104,6 +104,23 @@ func createMemoryActionConditionKeyMap() map[Action]condition.KeySet {
 		memoryActionConditionKeyMap[Action(act)] = condition.NewKeySet(commonKeys...)
 	}
 
+	// Enumeration keys apply only to the list actions. A read or a write names
+	// one record in its resource and has no query to constrain, so accepting
+	// them elsewhere would let a policy look effective while constraining
+	// nothing.
+	for _, act := range []MemoryAction{
+		MemoryListSecretsAction,
+		MemoryListAgentsAction,
+		MemoryListCortexesAction,
+		AllMemoryActions,
+	} {
+		memoryActionConditionKeyMap[Action(act)] = condition.NewKeySet(
+			append(commonKeys,
+				condition.MemoryPrefix.ToKey(),
+				condition.MemoryMaxKeys.ToKey(),
+			)...)
+	}
+
 	return memoryActionConditionKeyMap
 }
 

--- a/policy/memory-resource_test.go
+++ b/policy/memory-resource_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/minio/pkg/v3/policy/condition"
 )
 
 func TestParseMemoryResource(t *testing.T) {
@@ -727,13 +729,9 @@ func TestMemoryResourceStringNeverLeaksStorage(t *testing.T) {
 	}
 }
 
-// TestStarPrefixedResourceParses is a regression guard. Skipping the "*" entry
-// while looping the ARN prefixes made every string starting with "*" — "**",
-// "*foo" — fail to parse, which broke LoadPolicy for any stored policy using
-// one and surfaced as `invalid resource '**'` during IAM authorization.
-//
-// Only the exact string "*" is special-cased, so that its pattern stays "*"
-// rather than the empty remainder. Anything longer keeps what follows.
+// TestStarPrefixedResourceParses covers the wildcard forms. Only the exact
+// string "*" is special-cased; anything longer keeps what follows as its
+// pattern.
 func TestStarPrefixedResourceParses(t *testing.T) {
 	testCases := []struct {
 		value       string
@@ -782,5 +780,65 @@ func TestStarPrefixedResourceParses(t *testing.T) {
 		ObjectName:  "key",
 	}) {
 		t.Error(`"**" must still match every resource`)
+	}
+}
+
+// TestMemoryEnumerationConditionKeys covers the keys that scope a listing.
+//
+// A list names a query, not a record, so the prefix cannot live in the resource
+// path: one ARN would then mean a single record under memory:GetAgent and every
+// sibling sharing that prefix under memory:ListAgents, and an operator writing
+// both actions against one resource would leak names without any cue.
+func TestMemoryEnumerationConditionKeys(t *testing.T) {
+	listActions := []string{"memory:ListAgents", "memory:ListSecrets", "memory:ListCortexes"}
+	pointActions := []string{"memory:GetAgent", "memory:PutAgent", "memory:DeleteAgent", "memory:GetSecret"}
+
+	for _, action := range listActions {
+		keys, ok := MemoryActionConditionKeyMap[Action(action)]
+		if !ok {
+			t.Fatalf("%s has no condition key set", action)
+		}
+		for _, key := range []condition.KeyName{condition.MemoryPrefix, condition.MemoryMaxKeys} {
+			if !keys.Match(key.ToKey()) {
+				t.Errorf("%s does not accept %s", action, key)
+			}
+		}
+	}
+
+	// A read or a write has no query to constrain. Accepting the key there would
+	// let a policy look scoped while constraining nothing.
+	for _, action := range pointActions {
+		keys := MemoryActionConditionKeyMap[Action(action)]
+		if keys.Match(condition.MemoryPrefix.ToKey()) {
+			t.Errorf("%s must not accept %s", action, condition.MemoryPrefix)
+		}
+	}
+
+	// A whole policy using the key must validate.
+	const doc = `{"Version":"2012-10-17","Statement":[{
+		"Effect":"Allow",
+		"Action":["memory:ListAgents"],
+		"Resource":["arn:minio:memory:::cortex"],
+		"Condition":{"StringLike":{"memory:prefix":["alpha*"]}}}]}`
+	var p Policy
+	if err := json.Unmarshal([]byte(doc), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("a policy scoping enumeration by prefix must validate: %v", err)
+	}
+
+	// The same key on a read action must be refused, so the mistake surfaces at
+	// policy-write time rather than as a grant that silently does nothing.
+	const bad = `{"Version":"2012-10-17","Statement":[{
+		"Effect":"Allow",
+		"Action":["memory:GetAgent"],
+		"Resource":["arn:minio:memory:::cortex/agents/alpha"],
+		"Condition":{"StringLike":{"memory:prefix":["alpha*"]}}}]}`
+	var q Policy
+	if err := json.Unmarshal([]byte(bad), &q); err == nil {
+		if err := q.Validate(); err == nil {
+			t.Error("memory:prefix on a read action must be rejected")
+		}
 	}
 }

--- a/policy/memory-resource_test.go
+++ b/policy/memory-resource_test.go
@@ -726,3 +726,61 @@ func TestMemoryResourceStringNeverLeaksStorage(t *testing.T) {
 		}
 	}
 }
+
+// TestStarPrefixedResourceParses is a regression guard. Skipping the "*" entry
+// while looping the ARN prefixes made every string starting with "*" — "**",
+// "*foo" — fail to parse, which broke LoadPolicy for any stored policy using
+// one and surfaced as `invalid resource '**'` during IAM authorization.
+//
+// Only the exact string "*" is special-cased, so that its pattern stays "*"
+// rather than the empty remainder. Anything longer keeps what follows.
+func TestStarPrefixedResourceParses(t *testing.T) {
+	testCases := []struct {
+		value       string
+		wantPattern string
+	}{
+		{"*", "*"},
+		{"**", "*"},
+		{"***", "**"},
+		{"*foo", "foo"},
+	}
+
+	for _, tc := range testCases {
+		r, err := ParseResource(tc.value)
+		if err != nil {
+			t.Errorf("ParseResource(%q): unexpected error %v", tc.value, err)
+			continue
+		}
+		if r.Type != ResourceARNAll {
+			t.Errorf("ParseResource(%q): type = %v, want the wildcard type", tc.value, r.Type)
+		}
+		if r.Pattern != tc.wantPattern {
+			t.Errorf("ParseResource(%q): pattern = %q, want %q", tc.value, r.Pattern, tc.wantPattern)
+		}
+		if !r.IsValid() {
+			t.Errorf("ParseResource(%q): parsed but not valid", tc.value)
+		}
+		if r.IsBareARN() {
+			t.Errorf("ParseResource(%q): marked bare; only an ARN prefix is bare", tc.value)
+		}
+	}
+
+	// A policy carrying one must still load and match.
+	const doc = `{"Version":"2012-10-17","Statement":[{
+		"Effect":"Allow","Action":["s3:GetObject"],"Resource":["**"]}]}`
+	var p Policy
+	if err := json.Unmarshal([]byte(doc), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf(`a policy with "**" must load: %v`, err)
+	}
+	if !p.IsAllowed(Args{
+		AccountName: "u",
+		Action:      "s3:GetObject",
+		BucketName:  "bucket",
+		ObjectName:  "key",
+	}) {
+		t.Error(`"**" must still match every resource`)
+	}
+}

--- a/policy/resource.go
+++ b/policy/resource.go
@@ -316,13 +316,8 @@ func (r Resource) ValidateBucket(bucketName string) error {
 
 // ParseResource - parses string to Resource.
 func ParseResource(s string) (Resource, error) {
-	// "*" denotes every resource. It is matched here rather than in the loop
-	// below so its pattern stays "*" instead of the empty remainder; a longer
-	// string starting with "*" still falls through and keeps what follows as
-	// its pattern, so "**" and "*foo" parse as they always have.
-	//
-	// A bare ARN prefix, by contrast, names no resource and parses as its own
-	// type with an empty pattern.
+	// Matched here rather than in the loop below so the pattern stays "*" rather
+	// than the empty remainder CutPrefix would leave.
 	if s == ResourceARNAll.String() {
 		return Resource{Type: ResourceARNAll, Pattern: s}, nil
 	}

--- a/policy/resource.go
+++ b/policy/resource.go
@@ -316,17 +316,19 @@ func (r Resource) ValidateBucket(bucketName string) error {
 
 // ParseResource - parses string to Resource.
 func ParseResource(s string) (Resource, error) {
-	// "*" is the only string denoting every resource. A bare ARN prefix names
-	// none, and parses as its own type with an empty pattern.
+	// "*" denotes every resource. It is matched here rather than in the loop
+	// below so its pattern stays "*" instead of the empty remainder; a longer
+	// string starting with "*" still falls through and keeps what follows as
+	// its pattern, so "**" and "*foo" parse as they always have.
+	//
+	// A bare ARN prefix, by contrast, names no resource and parses as its own
+	// type with an empty pattern.
 	if s == ResourceARNAll.String() {
 		return Resource{Type: ResourceARNAll, Pattern: s}, nil
 	}
 
 	r := Resource{}
 	for k, v := range ARNPrefixToType {
-		if k == ResourceARNAll.String() {
-			continue
-		}
 		if rem, ok := strings.CutPrefix(s, k); ok {
 			r.Type = v
 			r.Pattern = rem

--- a/policy/resource_corpus_test.go
+++ b/policy/resource_corpus_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/minio/pkg/v3/policy/condition"
+)
+
+// acceptedResourceCorpus is every resource form the policy language accepts.
+//
+// ParseResource is shared by every ARN type, so a change made for one narrows
+// what the others accept. Adding a form here is a deliberate widening; removing
+// one is a breaking change for stored policies and has to be argued rather than
+// discovered downstream.
+var acceptedResourceCorpus = []string{
+	// Wildcards. Anything longer than "*" keeps what follows as its pattern.
+	//
+	// "**" is not exotic: String() renders the wildcard type as its prefix plus
+	// its pattern, so a policy written as "*" is re-serialized as "**". Any
+	// stored policy MinIO has read and written back carries that form.
+	"*",
+	"**",
+	"*foo",
+
+	// S3.
+	"arn:aws:s3:::bucket",
+	"arn:aws:s3:::bucket/*",
+	"arn:aws:s3:::bucket/key",
+	"arn:aws:s3:::bucket/a/b/c",
+	"arn:aws:s3:::*",
+	"arn:aws:s3:::bucket*",
+	"arn:aws:s3:::${aws:username}",
+	"arn:aws:s3:::bucket/${aws:username}/*",
+
+	// S3 Tables.
+	"arn:aws:s3tables:::bucket/wh/table/id",
+	"arn:aws:s3tables:::*",
+
+	// KMS.
+	"arn:minio:kms:::key",
+	"arn:minio:kms:::*",
+
+	// Memory.
+	"arn:minio:memory:::cortex",
+	"arn:minio:memory:::cortex/*",
+	"arn:minio:memory:::cortex/agents/alpha",
+	"arn:minio:memory:::cortex/agents/alpha/*",
+	"arn:minio:memory:::cortex/secrets/db/prod",
+	"arn:minio:memory:::*",
+
+	// Bare ARN prefixes. Inert and refused on write, but they must keep
+	// loading so a stored policy carrying one does not break on upgrade.
+	"arn:aws:s3:::",
+	"arn:aws:s3tables:::",
+	"arn:minio:kms:::",
+}
+
+// TestAcceptedResourceCorpusStillParses guards the shared parser against a
+// change made for one ARN type quietly rejecting another's inputs. Every entry
+// must parse, validate, and round-trip through its string form.
+func TestAcceptedResourceCorpusStillParses(t *testing.T) {
+	for _, value := range acceptedResourceCorpus {
+		t.Run(value, func(t *testing.T) {
+			r, err := ParseResource(value)
+			if err != nil {
+				t.Fatalf("no longer parses: %v", err)
+			}
+			if !r.IsValid() {
+				t.Fatalf("parsed but no longer valid: %#v", r)
+			}
+			// Assert the round trip is stable rather than byte-identical: "*"
+			// serializes to "**" and settles there, which is how the doubled
+			// form reaches stored policies in the first place.
+			again, err := ParseResource(r.String())
+			if err != nil {
+				t.Fatalf("re-parsing %q failed: %v", r.String(), err)
+			}
+			if again != r {
+				t.Errorf("round trip changed the resource: %#v -> %q -> %#v", r, r.String(), again)
+			}
+		})
+	}
+}
+
+// TestAcceptedResourceCorpusLoadsInAPolicy runs the same corpus through a whole
+// policy document, which is the path a deployment actually takes. A form that
+// parses in isolation but fails statement validation is just as broken.
+func TestAcceptedResourceCorpusLoadsInAPolicy(t *testing.T) {
+	for _, value := range acceptedResourceCorpus {
+		t.Run(value, func(t *testing.T) {
+			r, err := ParseResource(value)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+
+			// Pair each resource with an action of its own type; the two must
+			// agree or statement validation rejects the pair for that reason
+			// rather than for the resource itself.
+			action := "s3:GetObject"
+			switch r.Type {
+			case ResourceARNKMS:
+				action = "kms:ListKeys"
+			case ResourceARNS3Tables:
+				action = "s3tables:GetTableData"
+			case ResourceARNMemory:
+				action = "memory:GetAgent"
+			}
+
+			set := NewResourceSet(r)
+			statement := NewStatement("", Allow, NewActionSet(Action(action)), set, condition.NewFunctions())
+			if err := statement.Validate(); err != nil {
+				t.Fatalf("statement carrying %q no longer validates: %v", value, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Regression from #249.

Skipping the `"*"` entry while looping the ARN prefixes made every string that
merely *starts* with `*` fail to parse:

```
ParseResource("*"   ) -> type=* pattern="*" err=<nil>
ParseResource("**"  ) -> err=invalid resource '**'
ParseResource("*foo") -> err=invalid resource '*foo'
```

That breaks `LoadPolicy` for any stored policy using one. It surfaced in
aistor CI as an IAM authorization failure:

```
Error: invalid resource '**' (*grid.RemoteErr)
internal/grid/fanout.go:127:cmd.(*NotificationSys).LoadPolicy
```

The skip existed so a bare ARN prefix would stop parsing as the wildcard. That
property is unaffected: the exact string `"*"` is special-cased ahead of the
loop so its pattern stays `"*"` rather than the empty remainder, and a bare
prefix such as `arn:aws:s3:::` matches its own entry rather than the wildcard.

Verified by mutation — restoring the skip fails the new test on all three
inputs. `make lint` clean, full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of wildcard-prefixed resource patterns, including `*`, `**`, `***`, and `*foo`.
  * Policies using wildcard resource patterns now validate correctly and permit the expected S3 access.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->