### PR TITLE
fix(policy): trim the memory service prefix from condition key names

### DIFF
--- a/policy/condition/keyname.go
+++ b/policy/condition/keyname.go
@@ -39,7 +39,10 @@ var toTrim = map[string]bool{
 	"memory":   true,
 }
 
-// Name - returns key name which is stripped value of prefixes "aws:", "s3:", "jwt:" and "ldap:"
+// Name - returns the key name with its service prefix stripped, so a key reads
+// the request value of the same name. The prefixes that are stripped are the
+// keys of toTrim; a service missing from there keeps its whole name and reads a
+// value nothing populates.
 func (key KeyName) Name() string {
 	idx := strings.IndexByte(string(key), ':')
 	if idx == -1 || !toTrim[string(key[:idx])] {

--- a/policy/condition/keyname.go
+++ b/policy/condition/keyname.go
@@ -36,6 +36,7 @@ var toTrim = map[string]bool{
 	"svc":      true,
 	"s3":       true,
 	"s3tables": true,
+	"memory":   true,
 }
 
 // Name - returns key name which is stripped value of prefixes "aws:", "s3:", "jwt:" and "ldap:"

--- a/policy/condition/keyname_test.go
+++ b/policy/condition/keyname_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package condition
+
+import "testing"
+
+// TestServicePrefixedKeysResolveToRequestNames guards the mapping from a
+// condition key to the request value it reads.
+//
+// A key's service prefix is trimmed before lookup, so "s3:prefix" reads the
+// request's "prefix". A service missing from toTrim keeps its whole name and
+// therefore reads a value nothing populates: the condition then evaluates
+// false, and every statement carrying it silently grants nothing.
+func TestServicePrefixedKeysResolveToRequestNames(t *testing.T) {
+	testCases := []struct {
+		key  KeyName
+		want string
+	}{
+		{S3Prefix, "prefix"},
+		{S3Delimiter, "delimiter"},
+		{S3MaxKeys, "max-keys"},
+		{MemoryPrefix, "prefix"},
+		{MemoryMaxKeys, "max-keys"},
+		{AWSUsername, "username"},
+	}
+
+	for _, tc := range testCases {
+		if got := tc.key.Name(); got != tc.want {
+			t.Errorf("%s.Name() = %q, want %q; a key that keeps its service prefix reads a value nothing sets",
+				tc.key, got, tc.want)
+		}
+	}
+}
+
+// TestMemoryPrefixConditionEvaluates proves the key reaches a real request
+// value rather than merely parsing.
+func TestMemoryPrefixConditionEvaluates(t *testing.T) {
+	fn, err := newStringLikeFunc(MemoryPrefix.ToKey(), NewValueSet(NewStringValue("alpha*")), "")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	if !fn.evaluate(map[string][]string{"prefix": {"alpha"}}) {
+		t.Error(`prefix "alpha" must satisfy "alpha*"`)
+	}
+	if !fn.evaluate(map[string][]string{"prefix": {"alphabet"}}) {
+		t.Error(`prefix "alphabet" must satisfy "alpha*"`)
+	}
+	if fn.evaluate(map[string][]string{"prefix": {"beta"}}) {
+		t.Error(`prefix "beta" must not satisfy "alpha*"`)
+	}
+	// An unscoped listing must not pass a scoped condition.
+	if fn.evaluate(map[string][]string{}) {
+		t.Error("an absent prefix must not satisfy a scoped condition")
+	}
+}

--- a/policy/condition/keyname_test.go
+++ b/policy/condition/keyname_test.go
@@ -17,32 +17,38 @@
 
 package condition
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-// TestServicePrefixedKeysResolveToRequestNames guards the mapping from a
-// condition key to the request value it reads.
+// TestServicePrefixedKeysResolveToRequestNames guards the mapping from every
+// supported condition key to the request value it reads.
 //
-// A key's service prefix is trimmed before lookup, so "s3:prefix" reads the
+// A key's service prefix is stripped before lookup, so "s3:prefix" reads the
 // request's "prefix". A service missing from toTrim keeps its whole name and
-// therefore reads a value nothing populates: the condition then evaluates
-// false, and every statement carrying it silently grants nothing.
+// therefore reads a value nothing populates: the condition evaluates false, and
+// every statement carrying it silently grants nothing.
+//
+// The sweep is over AllSupportedKeys rather than a hand-picked list, so adding a
+// key for a new service without extending toTrim fails here instead of shipping
+// inert.
 func TestServicePrefixedKeysResolveToRequestNames(t *testing.T) {
-	testCases := []struct {
-		key  KeyName
-		want string
-	}{
-		{S3Prefix, "prefix"},
-		{S3Delimiter, "delimiter"},
-		{S3MaxKeys, "max-keys"},
-		{MemoryPrefix, "prefix"},
-		{MemoryMaxKeys, "max-keys"},
-		{AWSUsername, "username"},
-	}
+	for _, key := range AllSupportedKeys {
+		full := string(key)
+		idx := strings.IndexByte(full, ':')
+		if idx < 0 {
+			// Unprefixed keys read their own name.
+			if got := key.Name(); got != full {
+				t.Errorf("%s.Name() = %q, want %q", key, got, full)
+			}
+			continue
+		}
 
-	for _, tc := range testCases {
-		if got := tc.key.Name(); got != tc.want {
-			t.Errorf("%s.Name() = %q, want %q; a key that keeps its service prefix reads a value nothing sets",
-				tc.key, got, tc.want)
+		want := full[idx+1:]
+		if got := key.Name(); got != want {
+			t.Errorf("%s.Name() = %q, want %q; a key that keeps its service prefix reads a value nothing sets — add %q to toTrim",
+				key, got, want, full[:idx])
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #251, which added `memory:prefix` and `memory:max-keys`. Both were
inert as shipped.

A condition key's service prefix is stripped before it looks up the request
value — `toTrim` covers `aws`, `jwt`, `ldap`, `sts`, `svc`, `s3`, `s3tables` —
so `s3:prefix` reads the request's `prefix`. `memory` was missing:

```
s3:prefix     .Name() = "prefix"
memory:prefix .Name() = "memory:prefix"
evaluate against args[prefix]=alpha -> false
```

The key parsed, validated, and appeared in the action condition map, so a policy
using it loaded cleanly — and then granted nothing, because the condition never
matched. That is the failure mode the key was added to prevent: a grant that
looks scoped and silently isn't.

After the fix:

```
memory:prefix .Name() = "prefix"
prefix=alpha    vs alpha* -> true
prefix=alphabet vs alpha* -> true
prefix=beta     vs alpha* -> false
prefix absent             -> false
```

Tests assert the request-name mapping for every service-prefixed key, not just
the memory ones, so the next service added here fails loudly rather than
shipping inert. Mutation-checked: removing `memory` from `toTrim` fails both.