### PR TITLE
feat(policy): add S3TablesDeleteTableEncryptionAction

### DIFF
--- a/policy/table-action.go
+++ b/policy/table-action.go
@@ -37,6 +37,10 @@ const (
 	// S3TablesDeleteTableAction maps to the AWS `DeleteTable` S3 Tables action.
 	S3TablesDeleteTableAction TableAction = "s3tables:DeleteTable"
 
+	// S3TablesDeleteTableEncryptionAction is a MinIO extension for deleting a
+	// table-level encryption configuration override.
+	S3TablesDeleteTableEncryptionAction TableAction = "s3tables:DeleteTableEncryption"
+
 	// S3TablesDeleteTablePolicyAction maps to the AWS `DeleteTablePolicy` S3 Tables action.
 	S3TablesDeleteTablePolicyAction TableAction = "s3tables:DeleteTablePolicy"
 
@@ -257,6 +261,7 @@ var SupportedTableActions = map[TableAction]struct{}{
 	S3TablesDeleteTableBucketAction:                      {},
 	S3TablesDeleteTableBucketEncryptionAction:            {},
 	S3TablesDeleteTableBucketPolicyAction:                {},
+	S3TablesDeleteTableEncryptionAction:                  {},
 	S3TablesDeleteTablePolicyAction:                      {},
 	S3TablesGetNamespaceAction:                           {},
 	S3TablesGetTableAction:                               {},
@@ -401,6 +406,7 @@ func createTableActionConditionKeyMap() map[Action]condition.KeySet {
 	tableActionConditionKeyMap[Action(S3TablesDeleteTableBucketAction)] = withWarehouseCommon()
 	tableActionConditionKeyMap[Action(S3TablesDeleteTableBucketEncryptionAction)] = withWarehouseCommon()
 	tableActionConditionKeyMap[Action(S3TablesDeleteTableBucketPolicyAction)] = withWarehouseCommon()
+	tableActionConditionKeyMap[Action(S3TablesDeleteTableEncryptionAction)] = withTableCommon()
 	tableActionConditionKeyMap[Action(S3TablesDeleteTablePolicyAction)] = withTableCommon()
 	tableActionConditionKeyMap[Action(S3TablesGetNamespaceAction)] = withWarehouseCommon(s3TablesNamespaceKey)
 	tableActionConditionKeyMap[Action(S3TablesGetTableAction)] = withTableCommon()


### PR DESCRIPTION
## Summary
- Adds `S3TablesDeleteTableEncryptionAction` to `policy/table-action.go`,
  matching the existing table-level `S3TablesGetTableEncryptionAction` /
  `S3TablesPutTableEncryptionAction` pair.
- Registers it in the valid-action set and the table action condition-key
  map (`withTableCommon()`, matching `S3TablesDeleteTableAction`).

## Motivation
aistor pr: https://github.com/miniohq/aistor/pull/6693

Warehouse-level Iceberg encryption already has a full Put/Get/Delete action
set (`S3TablesPutWarehouseEncryptionAction`, `Get...`, `Delete...`), but the
table-level override only has Put/Get — there is no action a server can use
to authorize removing a table's encryption override. This is needed to add
a `DeleteTableEncryption` API to a downstream MinIO server implementation.

## Test plan
- [x] `go build ./...`
- [x] `go test ./policy/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the S3 Tables delete table encryption action.
  * The action is now recognized as a supported table-level operation and supports table-scoped conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->