### PR TITLE
feat(policy): add memory:GetObjectBio action

### DIFF
--- a/policy/memory-action.go
+++ b/policy/memory-action.go
@@ -65,8 +65,7 @@ const (
 	// MemorySearchAction - search (corpus-grep) the objects in a cortex.
 	MemorySearchAction MemoryAction = "memory:Search"
 
-	// MemoryGetObjectBioAction - read an object's version history in a cortex:
-	// who wrote each version, when, in which session, and what it carries.
+	// MemoryGetObjectBioAction - read an object's version history in a cortex.
 	MemoryGetObjectBioAction MemoryAction = "memory:GetObjectBio"
 
 	// AllMemoryActions - all AIStor Memory API actions.

--- a/policy/memory-action.go
+++ b/policy/memory-action.go
@@ -65,6 +65,10 @@ const (
 	// MemorySearchAction - search (corpus-grep) the objects in a cortex.
 	MemorySearchAction MemoryAction = "memory:Search"
 
+	// MemoryGetObjectBioAction - read an object's version history in a cortex:
+	// who wrote each version, when, in which session, and what it carries.
+	MemoryGetObjectBioAction MemoryAction = "memory:GetObjectBio"
+
 	// AllMemoryActions - all AIStor Memory API actions.
 	AllMemoryActions MemoryAction = "memory:*"
 )
@@ -84,6 +88,7 @@ var SupportedMemoryActions = map[MemoryAction]struct{}{
 	MemoryDeleteAgentAction:  {},
 	MemoryListAgentsAction:   {},
 	MemorySearchAction:       {},
+	MemoryGetObjectBioAction: {},
 	AllMemoryActions:         {},
 }
 

--- a/policy/memory-action.go
+++ b/policy/memory-action.go
@@ -65,7 +65,8 @@ const (
 	// MemorySearchAction - search (corpus-grep) the objects in a cortex.
 	MemorySearchAction MemoryAction = "memory:Search"
 
-	// MemoryGetObjectBioAction - read an object's version history in a cortex.
+	// MemoryGetObjectBioAction - read an object's biography in a cortex: who
+	// authored each version, when, and from where.
 	MemoryGetObjectBioAction MemoryAction = "memory:GetObjectBio"
 
 	// AllMemoryActions - all AIStor Memory API actions.

--- a/policy/memory-action_test.go
+++ b/policy/memory-action_test.go
@@ -39,6 +39,7 @@ func TestMemoryActionIsValid(t *testing.T) {
 		{MemoryDeleteAgentAction, true},
 		{MemoryListAgentsAction, true},
 		{MemorySearchAction, true},
+		{MemoryGetObjectBioAction, true},
 		{AllMemoryActions, true},
 		{MemoryAction("memory:FooBar"), false},
 		{MemoryAction("s3tables:CreateTable"), false},


### PR DESCRIPTION
## Summary

- Adds `MemoryGetObjectBioAction` (`memory:GetObjectBio`) to the AIStor Memory API action set, registers it in `SupportedMemoryActions`, and covers it in `TestMemoryActionIsValid`.
- The Memory API serves an object's version history at `GET /_mem/v1/cortexes/{cortex}/bio` — who wrote each version, when, in which session, and what it carries.
- Every other Memory route authorizes a `memory:*` action through `authorizeMemoryAction`. Without one for bio, that route has to borrow an S3 action, which puts S3 semantics into a Memory-native surface. This keeps the separation clean.

```
memory:GetObjectBio   on   arn:minio:memory:::<cortex>/objects/<key>
```

No condition keys are attached: `memory:prefix` and `memory:max-keys` are deliberately list-only, and bio names one key in its resource.

## Test plan

- [x] `go build ./...`
- [x] `go test ./policy/` — passes, including the extended `TestMemoryActionIsValid`
- [x] Additive only: no existing action, map entry, or behaviour changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `memory:GetObjectBio` memory action.

* **Tests**
  * Added validation coverage to confirm the new memory action is recognized as valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->