### PR TITLE
feat(policy): add MemoryGetObjectBioAction

### DIFF
--- a/policy/memory-action.go
+++ b/policy/memory-action.go
@@ -65,6 +65,12 @@ const (
 	// MemorySearchAction - search (corpus-grep) the objects in a cortex.
 	MemorySearchAction MemoryAction = "memory:Search"
 
+	// MemoryGetObjectBioAction - read an object's biography from a cortex:
+	// who authored each version of it, when, from which agent and session,
+	// and what that version carries. Distinct from reading the object, which
+	// returns the bytes and says nothing about who put them there.
+	MemoryGetObjectBioAction MemoryAction = "memory:GetObjectBio"
+
 	// AllMemoryActions - all AIStor Memory API actions.
 	AllMemoryActions MemoryAction = "memory:*"
 )
@@ -84,6 +90,7 @@ var SupportedMemoryActions = map[MemoryAction]struct{}{
 	MemoryDeleteAgentAction:  {},
 	MemoryListAgentsAction:   {},
 	MemorySearchAction:       {},
+	MemoryGetObjectBioAction: {},
 	AllMemoryActions:         {},
 }
 

--- a/policy/memory-action_test.go
+++ b/policy/memory-action_test.go
@@ -39,6 +39,7 @@ func TestMemoryActionIsValid(t *testing.T) {
 		{MemoryDeleteAgentAction, true},
 		{MemoryListAgentsAction, true},
 		{MemorySearchAction, true},
+		{MemoryGetObjectBioAction, true},
 		{AllMemoryActions, true},
 		{MemoryAction("memory:FooBar"), false},
 		{MemoryAction("s3tables:CreateTable"), false},


### PR DESCRIPTION
## Description

Adds `memory:GetObjectBio` to the Memory API action set.

## Motivation

AIStor's Memory API is growing an object-bio route that returns one object's
version history and per-version provenance. Every other Memory surface
authorizes a `memory:*` action via `authorizeMemoryAction`; without this
constant the route has to borrow an S3 action, which grants the caller more
than the route needs and makes it the one inconsistent member of the family.

Registered as a read rather than an enumeration: it names one record in its
resource and has no query to constrain, so `MemoryPrefix`/`MemoryMaxKeys` do
not apply.

## How to test

`go test ./policy/ -run Memory` — `TestMemoryActionIsValid` covers the new
constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `memory:GetObjectBio` action.
  - The action is now recognized as valid and available for action-based conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->