### PR TITLE
feat(policy): add memory:PutBioTables and memory:DeleteBioTables actions

### DIFF
--- a/policy/memory-action.go
+++ b/policy/memory-action.go
@@ -50,7 +50,19 @@ const (
 	// MemoryListSecretsAction - list the secrets in a cortex.
 	MemoryListSecretsAction MemoryAction = "memory:ListSecrets"
 
-	// MemoryPutAgentAction - write an agent record in a cortex.
+	// MemoryPutBioTablesAction - create an agent's telemetry namespace and
+	// tables in a cortex's warehouse. Separate from MemoryPutAgentAction because
+	// it writes the Tables catalog, so a principal that may write agent state
+	// must not gain it.
+	MemoryPutBioTablesAction MemoryAction = "memory:PutBioTables"
+
+	// MemoryDeleteBioTablesAction - delete an agent's telemetry namespace and
+	// tables from a cortex's warehouse. Carries the same privilege as creating
+	// them, over history the agent has already written.
+	MemoryDeleteBioTablesAction MemoryAction = "memory:DeleteBioTables"
+
+	// MemoryPutAgentAction - write an agent record, or a memory beneath one, in
+	// a cortex.
 	MemoryPutAgentAction MemoryAction = "memory:PutAgent"
 
 	// MemoryGetAgentAction - read an agent record from a cortex.
@@ -75,21 +87,23 @@ const (
 
 // SupportedMemoryActions - list of all supported AIStor Memory API actions.
 var SupportedMemoryActions = map[MemoryAction]struct{}{
-	MemoryCreateCortexAction: {},
-	MemoryDeleteCortexAction: {},
-	MemoryGetCortexAction:    {},
-	MemoryListCortexesAction: {},
-	MemoryPutSecretAction:    {},
-	MemoryGetSecretAction:    {},
-	MemoryDeleteSecretAction: {},
-	MemoryListSecretsAction:  {},
-	MemoryPutAgentAction:     {},
-	MemoryGetAgentAction:     {},
-	MemoryDeleteAgentAction:  {},
-	MemoryListAgentsAction:   {},
-	MemorySearchAction:       {},
-	MemoryGetObjectBioAction: {},
-	AllMemoryActions:         {},
+	MemoryCreateCortexAction:    {},
+	MemoryDeleteCortexAction:    {},
+	MemoryGetCortexAction:       {},
+	MemoryListCortexesAction:    {},
+	MemoryPutSecretAction:       {},
+	MemoryGetSecretAction:       {},
+	MemoryDeleteSecretAction:    {},
+	MemoryListSecretsAction:     {},
+	MemoryPutBioTablesAction:    {},
+	MemoryDeleteBioTablesAction: {},
+	MemoryPutAgentAction:        {},
+	MemoryGetAgentAction:        {},
+	MemoryDeleteAgentAction:     {},
+	MemoryListAgentsAction:      {},
+	MemorySearchAction:          {},
+	MemoryGetObjectBioAction:    {},
+	AllMemoryActions:            {},
 }
 
 // IsValid - checks if action is valid or not.

--- a/policy/memory-action_test.go
+++ b/policy/memory-action_test.go
@@ -34,6 +34,8 @@ func TestMemoryActionIsValid(t *testing.T) {
 		{MemoryGetSecretAction, true},
 		{MemoryDeleteSecretAction, true},
 		{MemoryListSecretsAction, true},
+		{MemoryPutBioTablesAction, true},
+		{MemoryDeleteBioTablesAction, true},
 		{MemoryPutAgentAction, true},
 		{MemoryGetAgentAction, true},
 		{MemoryDeleteAgentAction, true},

--- a/policy/memory-resource_test.go
+++ b/policy/memory-resource_test.go
@@ -812,8 +812,10 @@ func TestMemoryEnumerationConditionKeys(t *testing.T) {
 	// let a policy look scoped while constraining nothing.
 	for _, action := range pointActions {
 		keys := MemoryActionConditionKeyMap[Action(action)]
-		if keys.Match(condition.MemoryPrefix.ToKey()) {
-			t.Errorf("%s must not accept %s", action, condition.MemoryPrefix)
+		for _, key := range []condition.KeyName{condition.MemoryPrefix, condition.MemoryMaxKeys} {
+			if keys.Match(key.ToKey()) {
+				t.Errorf("%s must not accept %s", action, key)
+			}
 		}
 	}
 

--- a/policy/memory-resource_test.go
+++ b/policy/memory-resource_test.go
@@ -791,7 +791,10 @@ func TestStarPrefixedResourceParses(t *testing.T) {
 // both actions against one resource would leak names without any cue.
 func TestMemoryEnumerationConditionKeys(t *testing.T) {
 	listActions := []string{"memory:ListAgents", "memory:ListSecrets", "memory:ListCortexes"}
-	pointActions := []string{"memory:GetAgent", "memory:PutAgent", "memory:DeleteAgent", "memory:GetSecret"}
+	pointActions := []string{
+		"memory:GetAgent", "memory:PutAgent", "memory:DeleteAgent", "memory:GetSecret",
+		"memory:PutBioTables", "memory:DeleteBioTables",
+	}
 
 	for _, action := range listActions {
 		keys, ok := MemoryActionConditionKeyMap[Action(action)]


### PR DESCRIPTION
## Problem

The AIStor Memory API has no action that authorizes provisioning an agent's OpenTelemetry tables.

Those tables are created today by whichever client writes telemetry first, so their names and schemas can drift between the
ingest sidecar, the console and the CLI. A drift is only discovered when one writer fails against a table another client
created, and the failure surfaces far from the change that caused it.

Moving that definition to a single server-side owner needs a resource family of its own — `biotables`, addressed as
`arn:minio:memory:::<cortex>/biotables/<agent>`. No existing action authorizes it. `memory:PutAgent` is the wrong one: it
writes agent state, while provisioning telemetry writes the Tables catalog, so a principal allowed to write an agent must not
gain it by default.

## Fix

- `memory:PutBioTables` and `memory:DeleteBioTables`, registered in `SupportedMemoryActions` so they validate, parse and match.
- Both are point actions. Each names one agent's tables and carries no query to constrain, so neither accepts `memory:prefix`
  or `memory:max-keys`. `TestMemoryEnumerationConditionKeys` now asserts that, alongside the existing read and write actions.
- `memory:PutAgent`'s doc comment now says it covers a memory beneath an agent as well as the record itself, which is what the
  action has always authorized.

No behaviour changes for any existing action.

## Verification

```
$ go test ./policy/... -count=1
ok  	github.com/minio/pkg/v3/policy	0.631s
ok  	github.com/minio/pkg/v3/policy/condition	0.414s

$ make lint
Running lint check
0 issues.
```

Negative verification — dropping one registration from `SupportedMemoryActions` and re-running:

```
--- FAIL: TestMemoryActionIsValid (0.00s)
    memory-action_test.go:52: case 9: action memory:PutBioTables: expected: true, got: false
FAIL	github.com/minio/pkg/v3/policy	0.283s
```

Restored, and the suite is green again.

## Also included

Nothing. The branch is three files, all under `policy/`.

## Not fixed

The consumer in `miniohq/eos` is not part of this PR. It depends on these two actions and will follow once this lands and the
dependency is bumped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added policy actions for creating and deleting telemetry memory tables.
  * Updated agent memory permissions to include writing memories beneath an agent.

* **Bug Fixes**
  * Improved validation for table actions by rejecting unsupported memory prefix and maximum-key conditions.
  * Added coverage to verify the new actions are recognized as valid policy options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->