### PR TITLE
feat(policy): add memory:UpdateAgent action

### DIFF
--- a/policy/memory-action.go
+++ b/policy/memory-action.go
@@ -50,8 +50,14 @@ const (
 	// MemoryListSecretsAction - list the secrets in a cortex.
 	MemoryListSecretsAction MemoryAction = "memory:ListSecrets"
 
-	// MemoryPutAgentAction - write an agent record in a cortex.
+	// MemoryPutAgentAction - create an agent record, or write a memory beneath
+	// it. Create-only, so it is safe to grant alongside a memory write.
 	MemoryPutAgentAction MemoryAction = "memory:PutAgent"
+
+	// MemoryUpdateAgentAction - modify an existing agent record in a cortex. Separate
+	// from MemoryPutAgentAction, which only creates: an update re-derives the agent's
+	// IAM policy from its mounts, so it must be grantable without granting creation.
+	MemoryUpdateAgentAction MemoryAction = "memory:UpdateAgent"
 
 	// MemoryGetAgentAction - read an agent record from a cortex.
 	MemoryGetAgentAction MemoryAction = "memory:GetAgent"
@@ -84,6 +90,7 @@ var SupportedMemoryActions = map[MemoryAction]struct{}{
 	MemoryDeleteSecretAction: {},
 	MemoryListSecretsAction:  {},
 	MemoryPutAgentAction:     {},
+	MemoryUpdateAgentAction:  {},
 	MemoryGetAgentAction:     {},
 	MemoryDeleteAgentAction:  {},
 	MemoryListAgentsAction:   {},

--- a/policy/memory-action_test.go
+++ b/policy/memory-action_test.go
@@ -35,6 +35,7 @@ func TestMemoryActionIsValid(t *testing.T) {
 		{MemoryDeleteSecretAction, true},
 		{MemoryListSecretsAction, true},
 		{MemoryPutAgentAction, true},
+		{MemoryUpdateAgentAction, true},
 		{MemoryGetAgentAction, true},
 		{MemoryDeleteAgentAction, true},
 		{MemoryListAgentsAction, true},

--- a/policy/memory-resource_test.go
+++ b/policy/memory-resource_test.go
@@ -791,7 +791,10 @@ func TestStarPrefixedResourceParses(t *testing.T) {
 // both actions against one resource would leak names without any cue.
 func TestMemoryEnumerationConditionKeys(t *testing.T) {
 	listActions := []string{"memory:ListAgents", "memory:ListSecrets", "memory:ListCortexes"}
-	pointActions := []string{"memory:GetAgent", "memory:PutAgent", "memory:DeleteAgent", "memory:GetSecret"}
+	pointActions := []string{
+		"memory:GetAgent", "memory:PutAgent", "memory:DeleteAgent", "memory:GetSecret",
+		"memory:UpdateAgent",
+	}
 
 	for _, action := range listActions {
 		keys, ok := MemoryActionConditionKeyMap[Action(action)]
@@ -809,8 +812,10 @@ func TestMemoryEnumerationConditionKeys(t *testing.T) {
 	// let a policy look scoped while constraining nothing.
 	for _, action := range pointActions {
 		keys := MemoryActionConditionKeyMap[Action(action)]
-		if keys.Match(condition.MemoryPrefix.ToKey()) {
-			t.Errorf("%s must not accept %s", action, condition.MemoryPrefix)
+		for _, key := range []condition.KeyName{condition.MemoryPrefix, condition.MemoryMaxKeys} {
+			if keys.Match(key.ToKey()) {
+				t.Errorf("%s must not accept %s", action, key)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

The AIStor Cortex agent API splits into a create-only `PutAgent` and a separate
`UpdateAgent`, and there is no action for the second one. `memory:PutAgent` cannot
serve both: it also authorizes writing a memory beneath an agent, so a principal
allowed to write memories would gain the power to rewrite the record those memories
sit under. An update additionally re-derives the agent's IAM policy from its mounts,
which has to be grantable to a principal that may not create agents at all.

## Fix

- Add `MemoryUpdateAgentAction` (`memory:UpdateAgent`) and register it in
  `SupportedMemoryActions`, so it validates and `memory:*` covers it.
- Clarify `MemoryPutAgentAction`'s doc comment: it creates a record or writes a
  memory beneath one, and being create-only is what makes it safe to grant
  alongside a memory write.
- Tighten `TestMemoryEnumerationConditionKeys` to assert point actions reject
  `memory:max-keys` as well as `memory:prefix`. The list-action loop already
  checked both; the point-action loop checked only `prefix`, so a regression
  granting `max-keys` to a read or a write would have passed.

## Test plan

- [x] `go test ./policy/...` → 345 pass across both policy packages.
- [x] Negative-verified the registration: deleted the `SupportedMemoryActions`
      entry and `TestMemoryActionIsValid` failed with
      `case 10: action memory:UpdateAgent: expected: true, got: false`. Restored,
      green.
- [x] Negative-verified the tightened assertion by breaking the code it guards,
      not the test: appended `MemoryMaxKeys` to the common key set so every action
      accepted it, and `TestMemoryEnumerationConditionKeys` failed with
      `memory:GetAgent must not accept memory:max-keys` (and the same for
      `PutAgent`, `DeleteAgent`, `GetSecret`, `UpdateAgent`). Restored, green.
- [x] Working tree confirmed clean at `86495da` after both experiments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated memory-policy action for updating existing agent records, separate from create-only actions.

* **Bug Fixes**
  * Improved validation for agent update actions in memory policies.
  * Ensured prefix and maximum-key conditions are rejected for point-specific memory actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->