### PR TITLE
feat(policy): add s3tables table annotation actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ Packages are scoped by capability at the repo root (for example `policy`, `ldap`
 Run these commands before opening a pull request; they mirror the CI stack.
 
 ## Coding Style & Naming Conventions
+Call a non-AWS action, API, or behavior an **AIStor extension**, never a "MinIO extension" — the product is MinIO AIStor, and what these comments distinguish is what AWS defines from what AIStor adds.
+
 Always format Go sources with `gofmt`/`goimports`. Follow the CLAUDE guidance from `miniohq/eos`: keep comments minimal, explaining **why** the code exists, never **what**, and do not leave “removed because” notes when deleting code. Use descriptive package names that mirror directory names and exported identifiers with GoDoc-ready sentences. Stick to tab-indented Go style and avoid introducing logging or HTTP helpers that bypass established patterns in sibling MinIO repos without prior discussion.
 
 ## Testing Guidelines

--- a/policy/action.go
+++ b/policy/action.go
@@ -87,11 +87,11 @@ const (
 	ListBucketMultipartUploadsAction Action = "s3:ListBucketMultipartUploads"
 
 	// ListenNotificationAction - ListenNotification Rest API action.
-	// This is MinIO extension.
+	// This is an AIStor extension.
 	ListenNotificationAction Action = "s3:ListenNotification"
 
 	// ListenBucketNotificationAction - ListenBucketNotification Rest API action.
-	// This is MinIO extension.
+	// This is an AIStor extension.
 	ListenBucketNotificationAction Action = "s3:ListenBucketNotification"
 
 	// ListMultipartUploadPartsAction - ListParts Rest API action.
@@ -226,7 +226,7 @@ const (
 
 	// RestoreObjectAction - RestoreObject REST API action
 	RestoreObjectAction Action = "s3:RestoreObject"
-	// ResetBucketReplicationStateAction - MinIO extension API ResetBucketReplicationState to reset replication state
+	// ResetBucketReplicationStateAction - AIStor extension API ResetBucketReplicationState to reset replication state
 	// on a bucket
 	ResetBucketReplicationStateAction Action = "s3:ResetBucketReplicationState"
 

--- a/policy/constants.go
+++ b/policy/constants.go
@@ -318,6 +318,11 @@ var DefaultPolicies = []struct {
 						Action(S3TablesRenameFunctionAction),
 						Action(S3TablesDeleteFunctionAction),
 						Action(S3TablesRegisterFunctionAction),
+						// Table annotations
+						Action(S3TablesPutTableAnnotationAction),
+						Action(S3TablesGetTableAnnotationAction),
+						Action(S3TablesListTableAnnotationsAction),
+						Action(S3TablesDeleteTableAnnotationAction),
 						// Catalog config + metrics
 						Action(S3TablesGetConfigAction),
 						Action(S3TablesTableMetricsAction),
@@ -364,6 +369,9 @@ var DefaultPolicies = []struct {
 						// Function read
 						Action(S3TablesGetFunctionAction),
 						Action(S3TablesListFunctionsAction),
+						// Table annotation read
+						Action(S3TablesGetTableAnnotationAction),
+						Action(S3TablesListTableAnnotationsAction),
 						// Catalog config + metrics
 						Action(S3TablesGetConfigAction),
 						Action(S3TablesTableMetricsAction),

--- a/policy/table-action.go
+++ b/policy/table-action.go
@@ -247,6 +247,19 @@ const (
 	// S3TablesListTagsForTableAction is a MinIO extension for listing tags on tables.
 	S3TablesListTagsForTableAction TableAction = "s3tables:ListTagsForTable"
 
+	// S3TablesPutTableAnnotationAction is an AIStor extension for attaching a
+	// named annotation payload to a table.
+	S3TablesPutTableAnnotationAction TableAction = "s3tables:PutTableAnnotation"
+	// S3TablesGetTableAnnotationAction is an AIStor extension for reading one of a
+	// table's annotations.
+	S3TablesGetTableAnnotationAction TableAction = "s3tables:GetTableAnnotation"
+	// S3TablesListTableAnnotationsAction is an AIStor extension for listing a
+	// table's annotations.
+	S3TablesListTableAnnotationsAction TableAction = "s3tables:ListTableAnnotations"
+	// S3TablesDeleteTableAnnotationAction is an AIStor extension for removing one
+	// of a table's annotations.
+	S3TablesDeleteTableAnnotationAction TableAction = "s3tables:DeleteTableAnnotation"
+
 	// AllS3TablesActions - all Amazon S3 Tables actions
 	AllS3TablesActions TableAction = "s3tables:*"
 )
@@ -324,6 +337,10 @@ var SupportedTableActions = map[TableAction]struct{}{
 	S3TablesTagTableAction:                               {},
 	S3TablesUntagTableAction:                             {},
 	S3TablesListTagsForTableAction:                       {},
+	S3TablesPutTableAnnotationAction:                     {},
+	S3TablesGetTableAnnotationAction:                     {},
+	S3TablesListTableAnnotationsAction:                   {},
+	S3TablesDeleteTableAnnotationAction:                  {},
 	AllS3TablesActions:                                   {},
 }
 
@@ -469,6 +486,10 @@ func createTableActionConditionKeyMap() map[Action]condition.KeySet {
 	tableActionConditionKeyMap[Action(S3TablesTagTableAction)] = withTableCommon()
 	tableActionConditionKeyMap[Action(S3TablesUntagTableAction)] = withTableCommon()
 	tableActionConditionKeyMap[Action(S3TablesListTagsForTableAction)] = withTableCommon()
+	tableActionConditionKeyMap[Action(S3TablesPutTableAnnotationAction)] = withTableCommon()
+	tableActionConditionKeyMap[Action(S3TablesGetTableAnnotationAction)] = withTableCommon()
+	tableActionConditionKeyMap[Action(S3TablesListTableAnnotationsAction)] = withTableCommon()
+	tableActionConditionKeyMap[Action(S3TablesDeleteTableAnnotationAction)] = withTableCommon()
 
 	return tableActionConditionKeyMap
 }

--- a/policy/table-action.go
+++ b/policy/table-action.go
@@ -37,7 +37,7 @@ const (
 	// S3TablesDeleteTableAction maps to the AWS `DeleteTable` S3 Tables action.
 	S3TablesDeleteTableAction TableAction = "s3tables:DeleteTable"
 
-	// S3TablesDeleteTableEncryptionAction is a MinIO extension for deleting a
+	// S3TablesDeleteTableEncryptionAction is an AIStor extension for deleting a
 	// table-level encryption configuration override.
 	S3TablesDeleteTableEncryptionAction TableAction = "s3tables:DeleteTableEncryption"
 
@@ -95,156 +95,156 @@ const (
 	// S3TablesUpdateTableMetadataLocationAction maps to the AWS `UpdateTableMetadataLocation` S3 Tables action.
 	S3TablesUpdateTableMetadataLocationAction TableAction = "s3tables:UpdateTableMetadataLocation"
 
-	// S3TablesCreateWarehouseAction is a MinIO extension for Iceberg warehouse provisioning.
+	// S3TablesCreateWarehouseAction is an AIStor extension for Iceberg warehouse provisioning.
 	S3TablesCreateWarehouseAction TableAction = "s3tables:CreateWarehouse"
 
 	// S3TablesCreateTableBucketAction maps to the AWS `CreateTableBucket` S3 Tables action.
 	// Prefer using S3TablesCreateWarehouseAction instead.
 	S3TablesCreateTableBucketAction TableAction = "s3tables:CreateTableBucket"
 
-	// S3TablesDeleteWarehouseAction is a MinIO extension for deleting Iceberg warehouses.
+	// S3TablesDeleteWarehouseAction is an AIStor extension for deleting Iceberg warehouses.
 	S3TablesDeleteWarehouseAction TableAction = "s3tables:DeleteWarehouse"
 
 	// S3TablesDeleteTableBucketAction maps to the AWS `DeleteTableBucket` S3 Tables action.
 	// Prefer using S3TablesDeleteWarehouseAction instead.
 	S3TablesDeleteTableBucketAction TableAction = "s3tables:DeleteTableBucket"
 
-	// S3TablesDeleteWarehouseEncryptionAction is a MinIO extension for deleting warehouse encryption configuration.
+	// S3TablesDeleteWarehouseEncryptionAction is an AIStor extension for deleting warehouse encryption configuration.
 	S3TablesDeleteWarehouseEncryptionAction TableAction = "s3tables:DeleteWarehouseEncryption"
 
 	// S3TablesDeleteTableBucketEncryptionAction maps to the AWS `DeleteTableBucketEncryption` S3 Tables action.
 	// Prefer using S3TablesDeleteWarehouseEncryptionAction instead.
 	S3TablesDeleteTableBucketEncryptionAction TableAction = "s3tables:DeleteTableBucketEncryption"
 
-	// S3TablesDeleteWarehousePolicyAction is a MinIO extension for deleting warehouse policies.
+	// S3TablesDeleteWarehousePolicyAction is an AIStor extension for deleting warehouse policies.
 	S3TablesDeleteWarehousePolicyAction TableAction = "s3tables:DeleteWarehousePolicy"
 
 	// S3TablesDeleteTableBucketPolicyAction maps to the AWS `DeleteTableBucketPolicy` S3 Tables action.
 	// Prefer using S3TablesDeleteWarehousePolicyAction instead.
 	S3TablesDeleteTableBucketPolicyAction TableAction = "s3tables:DeleteTableBucketPolicy"
 
-	// S3TablesGetWarehouseAction is a MinIO extension for retrieving warehouse details.
+	// S3TablesGetWarehouseAction is an AIStor extension for retrieving warehouse details.
 	S3TablesGetWarehouseAction TableAction = "s3tables:GetWarehouse"
 
 	// S3TablesGetTableBucketAction maps to the AWS `GetTableBucket` S3 Tables action.
 	// Prefer using S3TablesGetWarehouseAction instead.
 	S3TablesGetTableBucketAction TableAction = "s3tables:GetTableBucket"
 
-	// S3TablesGetWarehouseEncryptionAction is a MinIO extension for retrieving warehouse encryption configuration.
+	// S3TablesGetWarehouseEncryptionAction is an AIStor extension for retrieving warehouse encryption configuration.
 	S3TablesGetWarehouseEncryptionAction TableAction = "s3tables:GetWarehouseEncryption"
 
 	// S3TablesGetTableBucketEncryptionAction maps to the AWS `GetTableBucketEncryption` S3 Tables action.
 	// Prefer using S3TablesGetWarehouseEncryptionAction instead.
 	S3TablesGetTableBucketEncryptionAction TableAction = "s3tables:GetTableBucketEncryption"
 
-	// S3TablesGetWarehouseMaintenanceConfigurationAction is a MinIO extension for retrieving warehouse maintenance configuration.
+	// S3TablesGetWarehouseMaintenanceConfigurationAction is an AIStor extension for retrieving warehouse maintenance configuration.
 	S3TablesGetWarehouseMaintenanceConfigurationAction TableAction = "s3tables:GetWarehouseMaintenanceConfiguration"
 
 	// S3TablesGetTableBucketMaintenanceConfigurationAction maps to the AWS `GetTableBucketMaintenanceConfiguration` S3 Tables action.
 	// Prefer using S3TablesGetWarehouseMaintenanceConfigurationAction instead.
 	S3TablesGetTableBucketMaintenanceConfigurationAction TableAction = "s3tables:GetTableBucketMaintenanceConfiguration"
 
-	// S3TablesGetWarehousePolicyAction is a MinIO extension for retrieving warehouse policies.
+	// S3TablesGetWarehousePolicyAction is an AIStor extension for retrieving warehouse policies.
 	S3TablesGetWarehousePolicyAction TableAction = "s3tables:GetWarehousePolicy"
 
 	// S3TablesGetTableBucketPolicyAction maps to the AWS `GetTableBucketPolicy` S3 Tables action.
 	// Prefer using S3TablesGetWarehousePolicyAction instead.
 	S3TablesGetTableBucketPolicyAction TableAction = "s3tables:GetTableBucketPolicy"
 
-	// S3TablesListWarehousesAction is a MinIO extension for listing Iceberg warehouses.
+	// S3TablesListWarehousesAction is an AIStor extension for listing Iceberg warehouses.
 	S3TablesListWarehousesAction TableAction = "s3tables:ListWarehouses"
 
 	// S3TablesListTableBucketsAction maps to the AWS `ListTableBuckets` S3 Tables action.
 	// Prefer using S3TablesListWarehousesAction instead.
 	S3TablesListTableBucketsAction TableAction = "s3tables:ListTableBuckets"
 
-	// S3TablesPutWarehouseEncryptionAction is a MinIO extension for setting warehouse encryption configuration.
+	// S3TablesPutWarehouseEncryptionAction is an AIStor extension for setting warehouse encryption configuration.
 	S3TablesPutWarehouseEncryptionAction TableAction = "s3tables:PutWarehouseEncryption"
 
 	// S3TablesPutTableBucketEncryptionAction maps to the AWS `PutTableBucketEncryption` S3 Tables action.
 	// Prefer using S3TablesPutWarehouseEncryptionAction instead.
 	S3TablesPutTableBucketEncryptionAction TableAction = "s3tables:PutTableBucketEncryption"
 
-	// S3TablesPutWarehouseMaintenanceConfigurationAction is a MinIO extension for setting warehouse maintenance configuration.
+	// S3TablesPutWarehouseMaintenanceConfigurationAction is an AIStor extension for setting warehouse maintenance configuration.
 	S3TablesPutWarehouseMaintenanceConfigurationAction TableAction = "s3tables:PutWarehouseMaintenanceConfiguration"
 
 	// S3TablesPutTableBucketMaintenanceConfigurationAction maps to the AWS `PutTableBucketMaintenanceConfiguration` S3 Tables action.
 	// Prefer using S3TablesPutWarehouseMaintenanceConfigurationAction instead.
 	S3TablesPutTableBucketMaintenanceConfigurationAction TableAction = "s3tables:PutTableBucketMaintenanceConfiguration"
 
-	// S3TablesPutWarehousePolicyAction is a MinIO extension for setting warehouse policies.
+	// S3TablesPutWarehousePolicyAction is an AIStor extension for setting warehouse policies.
 	S3TablesPutWarehousePolicyAction TableAction = "s3tables:PutWarehousePolicy"
 
 	// S3TablesPutTableBucketPolicyAction maps to the AWS `PutTableBucketPolicy` S3 Tables action.
 	// Prefer using S3TablesPutWarehousePolicyAction instead.
 	S3TablesPutTableBucketPolicyAction TableAction = "s3tables:PutTableBucketPolicy"
 
-	// S3TablesGetConfigAction is a MinIO extension for retrieving catalog configuration.
+	// S3TablesGetConfigAction is an AIStor extension for retrieving catalog configuration.
 	S3TablesGetConfigAction TableAction = "s3tables:GetConfig"
 
-	// S3TablesTableMetricsAction is a MinIO extension exposing table metrics.
+	// S3TablesTableMetricsAction is an AIStor extension exposing table metrics.
 	S3TablesTableMetricsAction TableAction = "s3tables:TableMetrics"
 
-	// S3TablesUpdateTableAction is a MinIO extension for Iceberg-compatible table updates.
+	// S3TablesUpdateTableAction is an AIStor extension for Iceberg-compatible table updates.
 	S3TablesUpdateTableAction TableAction = "s3tables:UpdateTable"
 
-	// S3TablesCreateViewAction is a MinIO extension for creating Iceberg views.
+	// S3TablesCreateViewAction is an AIStor extension for creating Iceberg views.
 	S3TablesCreateViewAction TableAction = "s3tables:CreateView"
 
-	// S3TablesDeleteViewAction is a MinIO extension for deleting Iceberg views.
+	// S3TablesDeleteViewAction is an AIStor extension for deleting Iceberg views.
 	S3TablesDeleteViewAction TableAction = "s3tables:DeleteView"
 
-	// S3TablesGetViewAction is a MinIO extension for retrieving Iceberg views.
+	// S3TablesGetViewAction is an AIStor extension for retrieving Iceberg views.
 	S3TablesGetViewAction TableAction = "s3tables:GetView"
 
-	// S3TablesRenameViewAction is a MinIO extension for renaming Iceberg views.
+	// S3TablesRenameViewAction is an AIStor extension for renaming Iceberg views.
 	S3TablesRenameViewAction TableAction = "s3tables:RenameView"
 
-	// S3TablesUpdateViewAction is a MinIO extension for updating Iceberg views.
+	// S3TablesUpdateViewAction is an AIStor extension for updating Iceberg views.
 	S3TablesUpdateViewAction TableAction = "s3tables:UpdateView"
 
-	// S3TablesListViewsAction is a MinIO extension for listing Iceberg views.
+	// S3TablesListViewsAction is an AIStor extension for listing Iceberg views.
 	S3TablesListViewsAction TableAction = "s3tables:ListViews"
 
-	// S3TablesRegisterViewAction is a MinIO extension for registering Iceberg views.
+	// S3TablesRegisterViewAction is an AIStor extension for registering Iceberg views.
 	S3TablesRegisterViewAction TableAction = "s3tables:RegisterView"
 
-	// S3TablesCreateFunctionAction is a MinIO extension for creating Iceberg functions (SQL UDFs).
+	// S3TablesCreateFunctionAction is an AIStor extension for creating Iceberg functions (SQL UDFs).
 	S3TablesCreateFunctionAction TableAction = "s3tables:CreateFunction"
 
-	// S3TablesDeleteFunctionAction is a MinIO extension for deleting Iceberg functions (SQL UDFs).
+	// S3TablesDeleteFunctionAction is an AIStor extension for deleting Iceberg functions (SQL UDFs).
 	S3TablesDeleteFunctionAction TableAction = "s3tables:DeleteFunction"
 
-	// S3TablesGetFunctionAction is a MinIO extension for retrieving Iceberg functions (SQL UDFs).
+	// S3TablesGetFunctionAction is an AIStor extension for retrieving Iceberg functions (SQL UDFs).
 	S3TablesGetFunctionAction TableAction = "s3tables:GetFunction"
 
-	// S3TablesRenameFunctionAction is a MinIO extension for renaming Iceberg functions (SQL UDFs).
+	// S3TablesRenameFunctionAction is an AIStor extension for renaming Iceberg functions (SQL UDFs).
 	S3TablesRenameFunctionAction TableAction = "s3tables:RenameFunction"
 
-	// S3TablesUpdateFunctionAction is a MinIO extension for updating Iceberg functions (SQL UDFs).
+	// S3TablesUpdateFunctionAction is an AIStor extension for updating Iceberg functions (SQL UDFs).
 	S3TablesUpdateFunctionAction TableAction = "s3tables:UpdateFunction"
 
-	// S3TablesListFunctionsAction is a MinIO extension for listing Iceberg functions (SQL UDFs).
+	// S3TablesListFunctionsAction is an AIStor extension for listing Iceberg functions (SQL UDFs).
 	S3TablesListFunctionsAction TableAction = "s3tables:ListFunctions"
 
-	// S3TablesRegisterFunctionAction is a MinIO extension for registering Iceberg functions (SQL UDFs).
+	// S3TablesRegisterFunctionAction is an AIStor extension for registering Iceberg functions (SQL UDFs).
 	S3TablesRegisterFunctionAction TableAction = "s3tables:RegisterFunction"
 
-	// S3TablesUpdateNamespacePropertiesAction is a MinIO extension for updating namespace properties.
+	// S3TablesUpdateNamespacePropertiesAction is an AIStor extension for updating namespace properties.
 	S3TablesUpdateNamespacePropertiesAction TableAction = "s3tables:UpdateNamespaceProperties"
 
-	// S3TablesTagWarehouseAction is a MinIO extension for tagging Iceberg warehouses.
+	// S3TablesTagWarehouseAction is an AIStor extension for tagging Iceberg warehouses.
 	S3TablesTagWarehouseAction TableAction = "s3tables:TagWarehouse"
-	// S3TablesUntagWarehouseAction is a MinIO extension for removing tags from Iceberg warehouses.
+	// S3TablesUntagWarehouseAction is an AIStor extension for removing tags from Iceberg warehouses.
 	S3TablesUntagWarehouseAction TableAction = "s3tables:UntagWarehouse"
-	// S3TablesListTagsForWarehouseAction is a MinIO extension for listing tags on Iceberg warehouses.
+	// S3TablesListTagsForWarehouseAction is an AIStor extension for listing tags on Iceberg warehouses.
 	S3TablesListTagsForWarehouseAction TableAction = "s3tables:ListTagsForWarehouse"
 
-	// S3TablesTagTableAction is a MinIO extension for tagging tables.
+	// S3TablesTagTableAction is an AIStor extension for tagging tables.
 	S3TablesTagTableAction TableAction = "s3tables:TagTable"
-	// S3TablesUntagTableAction is a MinIO extension for removing tags from tables.
+	// S3TablesUntagTableAction is an AIStor extension for removing tags from tables.
 	S3TablesUntagTableAction TableAction = "s3tables:UntagTable"
-	// S3TablesListTagsForTableAction is a MinIO extension for listing tags on tables.
+	// S3TablesListTagsForTableAction is an AIStor extension for listing tags on tables.
 	S3TablesListTagsForTableAction TableAction = "s3tables:ListTagsForTable"
 
 	// S3TablesPutTableAnnotationAction is an AIStor extension for attaching a


### PR DESCRIPTION
Adds four `s3tables` actions for table annotations — named payloads attached to an
Iceberg table, the table-side counterpart of the S3 object annotation API:

- `s3tables:PutTableAnnotation`
- `s3tables:GetTableAnnotation`
- `s3tables:ListTableAnnotations`
- `s3tables:DeleteTableAnnotation`

Each carries the usual table condition keys (`withTableCommon`), so a policy can scope
them by warehouse, namespace, or table name. All four join the `tablesReadWrite` built-in
policy; the two read actions join `tablesReadOnly`.

Annotations could have borrowed the object annotation actions (`s3:PutObjectAnnotation`
and friends), but those authorize against an object resource. Table annotations belong to
a table, so they get their own actions and evaluate against the table ARN.

The second commit renames "MinIO extension" to "AIStor extension" in the policy action
docs and records the rule in `AGENTS.md`: the product is MinIO AIStor, and what these
comments distinguish is what AWS defines from what AIStor adds.

Required by the AIStor table annotations change, which cannot compile until this lands.

Validation: `go build ./policy/...`, `go test ./policy/...`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permissions for creating, reading, listing, and deleting table annotations.
  * Added support for table annotation actions and related access controls.
  * Updated standard table policies to include appropriate annotation permissions.

* **Documentation**
  * Updated extension terminology from “MinIO” to “AIStor” across policy descriptions and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->