### PR TITLE
feat(policy): let memory:prefix scope memory:Search

### DIFF
--- a/policy/condition/keyname.go
+++ b/policy/condition/keyname.go
@@ -134,10 +134,14 @@ const (
 	S3Delimiter KeyName = "s3:delimiter"
 
 	// MemoryPrefix - key representing the prefix query parameter of the AIStor
-	// Memory list APIs only. It scopes enumeration within a cortex, which a
-	// resource ARN cannot express: a list names a query, not a record, so
+	// Memory list and search APIs. It scopes enumeration within a cortex, which
+	// a resource ARN cannot express: a list names a query, not a record, so
 	// putting the prefix in the resource path would make one ARN mean a single
 	// record under a read action and a set of siblings under a list action.
+	//
+	// memory:Search takes it for the same reason and depends on it more, since
+	// search returns object content: without the key its grant has only two
+	// states, none or the whole cortex.
 	MemoryPrefix KeyName = "memory:prefix"
 
 	// MemoryMaxKeys - key representing the limit query parameter of the AIStor

--- a/policy/memory-action.go
+++ b/policy/memory-action.go
@@ -109,14 +109,22 @@ func createMemoryActionConditionKeyMap() map[Action]condition.KeySet {
 		memoryActionConditionKeyMap[Action(act)] = condition.NewKeySet(commonKeys...)
 	}
 
-	// Enumeration keys apply only to the list actions. A read or a write names
-	// one record in its resource and has no query to constrain, so accepting
-	// them elsewhere would let a policy look effective while constraining
-	// nothing.
+	// Enumeration keys apply only to the actions that carry a query. A read or a
+	// write names one record in its resource and has nothing to constrain, so
+	// accepting them elsewhere would let a policy look effective while
+	// constraining nothing.
+	//
+	// Search belongs here for the same reason a list does, and needs it more: it
+	// reads the CONTENT of every object under its prefix, so without the key the
+	// grant has two states -- no search, or search over the whole cortex. Its
+	// resource cannot carry the prefix either, by the argument above: one ARN
+	// would mean a single record under memory:GetObjectBio and every object
+	// sharing that prefix under memory:Search.
 	for _, act := range []MemoryAction{
 		MemoryListSecretsAction,
 		MemoryListAgentsAction,
 		MemoryListCortexesAction,
+		MemorySearchAction,
 		AllMemoryActions,
 	} {
 		memoryActionConditionKeyMap[Action(act)] = condition.NewKeySet(

--- a/policy/memory-resource_test.go
+++ b/policy/memory-resource_test.go
@@ -790,8 +790,13 @@ func TestStarPrefixedResourceParses(t *testing.T) {
 // sibling sharing that prefix under memory:ListAgents, and an operator writing
 // both actions against one resource would leak names without any cue.
 func TestMemoryEnumerationConditionKeys(t *testing.T) {
-	listActions := []string{"memory:ListAgents", "memory:ListSecrets", "memory:ListCortexes"}
-	pointActions := []string{"memory:GetAgent", "memory:PutAgent", "memory:DeleteAgent", "memory:GetSecret"}
+	// memory:Search carries a query like a list does, and is the case that most
+	// needs the key: it returns object CONTENT, so a grant that cannot be scoped
+	// to a prefix is a grant over every object in the cortex.
+	listActions := []string{
+		"memory:ListAgents", "memory:ListSecrets", "memory:ListCortexes", "memory:Search",
+	}
+	pointActions := []string{"memory:GetAgent", "memory:PutAgent", "memory:DeleteAgent", "memory:GetSecret", "memory:GetObjectBio"}
 
 	for _, action := range listActions {
 		keys, ok := MemoryActionConditionKeyMap[Action(action)]
@@ -814,12 +819,13 @@ func TestMemoryEnumerationConditionKeys(t *testing.T) {
 		}
 	}
 
-	// A whole policy using the key must validate.
+	// A whole policy using the key must validate -- written against
+	// memory:Search, the shape a workspace-scoped credential needs.
 	const doc = `{"Version":"2012-10-17","Statement":[{
 		"Effect":"Allow",
-		"Action":["memory:ListAgents"],
+		"Action":["memory:Search"],
 		"Resource":["arn:minio:memory:::cortex"],
-		"Condition":{"StringLike":{"memory:prefix":["alpha*"]}}}]}`
+		"Condition":{"StringLike":{"memory:prefix":["workspaces/alice/app-7/*"]}}}]}`
 	var p Policy
 	if err := json.Unmarshal([]byte(doc), &p); err != nil {
 		t.Fatalf("unmarshal: %v", err)

--- a/policy/memory-resource_test.go
+++ b/policy/memory-resource_test.go
@@ -810,12 +810,16 @@ func TestMemoryEnumerationConditionKeys(t *testing.T) {
 		}
 	}
 
-	// A read or a write has no query to constrain. Accepting the key there would
-	// let a policy look scoped while constraining nothing.
+	// A read or a write has no query to constrain. Accepting either key there
+	// would let a policy look scoped while constraining nothing -- both are
+	// checked, since a rejection test that covers one key cannot show the other
+	// was not quietly admitted.
 	for _, action := range pointActions {
 		keys := MemoryActionConditionKeyMap[Action(action)]
-		if keys.Match(condition.MemoryPrefix.ToKey()) {
-			t.Errorf("%s must not accept %s", action, condition.MemoryPrefix)
+		for _, key := range []condition.KeyName{condition.MemoryPrefix, condition.MemoryMaxKeys} {
+			if keys.Match(key.ToKey()) {
+				t.Errorf("%s must not accept %s", action, key)
+			}
 		}
 	}
 


### PR DESCRIPTION
`memory:prefix` already exists and already scopes the list actions. `memory:Search` was left out, and it is the action that needs it most: a list returns names, a search returns the **content** of every object under its prefix. So the grant has exactly two states today — no search at all, or search over every object in the cortex.

That matters wherever one cortex holds more than one tenant's data. A credential scoped to a single prefix can read only its own objects over S3, and then either cannot search at all or can grep everyone's.

## Measured, not inferred

Against a live server, minting STS sessions with inline policies over a cortex holding `workspaces/alice/app-7/` and `workspaces/bob/app-9/`:

| session policy | result |
| --- | --- |
| cortex ARN + `arn:minio:memory:::<cortex>/workspaces/alice/app-7/*` | search runs, and a request for **bob's** prefix returns bob's content |
| `arn:minio:memory:::<cortex>/workspaces/alice/app-7/*` alone | 403 on every search, including the session's own prefix |
| cortex ARN alone | search runs over the whole cortex |

The key-level resource is inert for this action: present it grants nothing, absent nothing is lost.

## Why the condition key rather than the resource

`condition.MemoryPrefix`'s own doc comment already makes the argument for lists, and it transfers unchanged — a search names a query, not a record, so putting the prefix in the resource path would make one ARN mean a single object under `memory:GetObjectBio` and every object sharing that prefix under `memory:Search`. This is the same relationship `s3:prefix` has with `s3:ListBucket`.

## The change

`MemorySearchAction` joins the actions that accept the enumeration condition keys, so a policy can say:

```json
{
  "Effect": "Allow",
  "Action": ["memory:Search"],
  "Resource": ["arn:minio:memory:::orb"],
  "Condition": {"StringLike": {"memory:prefix": ["workspaces/alice/app-7/*"]}}
}
```

Additive. A statement carrying no condition behaves exactly as it does today, and the point actions still reject the key — `memory:GetObjectBio` is now covered by that half of `TestMemoryEnumerationConditionKeys`, having been absent from it.

## Server side

The server must populate the value and, critically, search the same prefix it authorized. That lands separately in aistor: the search prefix moves into the query string (the only place `getConditionValues` looks), and a request whose query and body prefixes disagree is refused rather than reconciled — authorizing one prefix and walking a wider one is the failure worth guarding against.

Verified end to end against a server carrying both changes: a session scoped to one workspace searches its own prefix, is refused another's, and is refused a cortex-wide search; an unconditioned session behaves exactly as before.

`go test ./policy/...` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for scoping memory searches with memory-prefix conditions.
  - Added maximum-key conditions to memory search actions.
  - Improved policy controls for workspace-scoped memory search and unrestricted content access.

- **Documentation**
  - Clarified how memory-prefix conditions apply to memory listing and search APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->